### PR TITLE
feat(nextjs): scaffold App Router app with Tailwind under next-app/

### DIFF
--- a/next-app/.gitignore
+++ b/next-app/.gitignore
@@ -1,0 +1,4 @@
+.next
+out
+node_modules
+.next-static

--- a/next-app/app/globals.css
+++ b/next-app/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: #0a0a0a;
+}
+
+html, body {
+  background-color: var(--background);
+}

--- a/next-app/app/layout.tsx
+++ b/next-app/app/layout.tsx
@@ -1,0 +1,21 @@
+import './globals.css';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'David Ortiz — Developer Portfolio',
+  description: 'Modern, fast portfolio with Next.js App Router and Tailwind CSS',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-neutral-950 text-neutral-100 antialiased">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -1,0 +1,24 @@
+export default function Home() {
+  return (
+    <main className="mx-auto max-w-4xl p-6">
+      <section className="mt-16 text-center">
+        <h1 className="text-3xl sm:text-5xl font-semibold tracking-tight">David Ortiz — Developer Portfolio</h1>
+        <p className="mt-4 text-neutral-300">Next.js App Router scaffold. Tailwind CSS configured. Progressive migration from current static site.</p>
+        <div className="mt-8 flex items-center justify-center gap-4">
+          <a
+            href="/"
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 transition-colors"
+          >
+            View current site
+          </a>
+          <a
+            href="https://cs-learning.me"
+            className="rounded-md border border-neutral-700 px-4 py-2 text-sm font-medium text-neutral-200 hover:bg-neutral-800 transition-colors"
+          >
+            cs-learning.me
+          </a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/next-app/next-env.d.ts
+++ b/next-app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-app/next.config.js
+++ b/next-app/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+module.exports = nextConfig;

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "next-app",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.10",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.12",
+    "@types/react": "18.2.66",
+    "@types/react-dom": "18.2.22",
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5"
+  }
+}

--- a/next-app/postcss.config.js
+++ b/next-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/next-app/tailwind.config.ts
+++ b/next-app/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/next-app/tsconfig.json
+++ b/next-app/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR introduces a minimal Next.js 14 App Router scaffold under `next-app/` to begin a progressive migration from the current static site.

Included:
- `package.json` with Next 14, React 18, TypeScript, Tailwind
- `next.config.js`, `tsconfig.json`, `next-env.d.ts`
- Tailwind setup: `postcss.config.js`, `tailwind.config.ts`, `app/globals.css`
- App Router entry: `app/layout.tsx`, `app/page.tsx`
- `.gitignore`

Notes:
- Does not change the current site or deployment behavior. Follow-up PR can configure Vercel `rootDirectory` to `next-app/` when ready.
- We can migrate sections incrementally and preserve the existing static site in parallel.

Next steps:
- Add shared components and port content from `index.html`
- Configure CI & Vercel preview for `next-app/`
- Align README badges once the migration crosses parity
