### PR TITLE
[codex] Align portfolio ecosystem links

### DIFF
--- a/lib/contact-links.ts
+++ b/lib/contact-links.ts
@@ -116,6 +116,6 @@ export const footerPrimaryLinks: ContactLink[] = [
 
 export const footerEcosystemLinks: ContactLink[] = [
   hireMeLinks[2],
-  followWorkLinks[1],
   followWorkLinks[2],
+  followWorkLinks[3],
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-v0-project",
+  "name": "david-ortiz-portfolio",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-v0-project",
+      "name": "david-ortiz-portfolio",
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-v0-project",
+  "name": "david-ortiz-portfolio",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- rename the package metadata from the v0 placeholder to david-ortiz-portfolio
- fix the footer ecosystem links so Prompt Defenders appears instead of LinkedIn
- update the lockfile name metadata to match package.json

## Validation
- npm run lint
- npm run build
- npm audit --omit=dev