### PR TITLE
Point CSBrainAI links to live alias

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -14,7 +14,7 @@ const SYSTEM_PROMPT = `You are an AI assistant for David Ortiz's personal site (
 
 ## Ecosystem Sites:
 - **High Encode Learning** (${businessSiteUrl}) - The business-facing site for services, demos, project scoping, and business work
-- **CSBrainAI** (csbrainai.com) - Retrieval and explanation experiments for technical knowledge
+- **CSBrainAI** (csbrainai.vercel.app) - Retrieval and explanation experiments for technical knowledge
 - **Prompt Defenders** (prompt-defenders.vercel.app) - AI security testing and prompt-safety work
 
 ## Guidance:

--- a/app/design-system/page.tsx
+++ b/app/design-system/page.tsx
@@ -505,7 +505,7 @@ export default function DesignSystemPage() {
             <span className="text-neutral-600">David Ortiz Design System</span>
           </div>
           <p className="text-sm text-neutral-400">
-            Powering the {personalSitePublicLabel}, {businessSiteDomain}, csbrainai.com, and prompt-defenders.vercel.app
+            Powering the {personalSitePublicLabel}, {businessSiteDomain}, csbrainai.vercel.app, and prompt-defenders.vercel.app
           </p>
         </div>
       </footer>

--- a/components/creative/command-palette.tsx
+++ b/components/creative/command-palette.tsx
@@ -38,7 +38,7 @@ const sites: Site[] = [
   {
     id: "csbrain",
     name: "CSBrainAI",
-    url: "https://csbrain.ai",
+    url: "https://csbrainai.vercel.app",
     icon: <Brain className="w-5 h-5" />,
     description: "AI Learning Assistant",
     gradient: "from-purple-400 to-pink-400",

--- a/components/ecosystem-banner.tsx
+++ b/components/ecosystem-banner.tsx
@@ -22,7 +22,7 @@ const ecosystemLinks: EcosystemLink[] = [
   },
   {
     name: "CSBrainAI",
-    href: "https://csbrain.ai",
+    href: "https://csbrainai.vercel.app",
     description: "Retrieval and explanation experiments",
   },
   {

--- a/components/ecosystem/ecosystem-banner-dark.tsx
+++ b/components/ecosystem/ecosystem-banner-dark.tsx
@@ -16,7 +16,7 @@ const ecosystemSites = [
   },
   {
     name: "CSBrainAI",
-    href: "https://csbrain.ai",
+    href: "https://csbrainai.vercel.app",
     description: "Retrieval experiments",
   },
   {

--- a/components/ecosystem/ecosystem-banner-light.tsx
+++ b/components/ecosystem/ecosystem-banner-light.tsx
@@ -16,7 +16,7 @@ const ecosystemSites = [
   },
   {
     name: "CSBrainAI",
-    href: "https://csbrain.ai",
+    href: "https://csbrainai.vercel.app",
     description: "Retrieval experiments",
   },
   {

--- a/components/ui-creative/ecosystem-links.tsx
+++ b/components/ui-creative/ecosystem-links.tsx
@@ -25,7 +25,7 @@ const ecosystemItems = [
     name: "CSBrainAI",
     description: "Retrieval and explanation experiments",
     icon: Brain,
-    url: "https://csbrain.ai",
+    url: "https://csbrainai.vercel.app",
     gradient: "from-purple-500 to-pink-500",
     features: ["Grounded answers", "Knowledge interfaces", "Explanation quality"],
   },

--- a/components/unified-footer.tsx
+++ b/components/unified-footer.tsx
@@ -22,7 +22,7 @@ const footerSections = {
   tools: {
     title: "Tools",
     links: [
-      { name: "CSBrainAI", href: "https://csbrain.ai", external: true },
+      { name: "CSBrainAI", href: "https://csbrainai.vercel.app", external: true },
       { name: "Prompt Defenders", href: "https://prompt-defenders.vercel.app", external: true },
     ],
   },

--- a/lib/contact-links.ts
+++ b/lib/contact-links.ts
@@ -84,7 +84,7 @@ export const followWorkLinks: ContactLink[] = [
   {
     id: "csbrainai",
     label: "CSBrainAI",
-    href: "https://csbrain.ai",
+    href: "https://csbrainai.vercel.app",
     description: "Retrieval and explanation experiments around technical knowledge delivery.",
   },
   {

--- a/lib/design-system/site-configs.ts
+++ b/lib/design-system/site-configs.ts
@@ -108,7 +108,7 @@ export const siteConfigs: Record<SiteKey, SiteConfig> = {
   // ---------------------------------------------------------------------------
   csBrainAI: {
     name: "CSBrain AI",
-    domain: "csbrainai.com",
+    domain: "csbrainai.vercel.app",
     tagline: "Retrieval and explanation experiments",
     theme: "dark",
     colors: tokens.colors.sites.csBrainAI,

--- a/lib/design-system/tokens.ts
+++ b/lib/design-system/tokens.ts
@@ -1,6 +1,6 @@
 // =============================================================================
 // DESIGN SYSTEM TOKENS
-// Shared across: davidtiz.com, highencodelearning.com, csbrain.ai, and prompt-defenders.vercel.app
+// Shared across: davidtiz.com, highencodelearning.com, csbrainai.vercel.app, and prompt-defenders.vercel.app
 // =============================================================================
 
 export const tokens = {


### PR DESCRIPTION
## Summary
- replace dead csbrain.ai and stale csbrainai.com references with the public csbrainai.vercel.app alias
- update footer, command palette, ecosystem banners, design-system copy, and chat context

## Validation
- npm run lint
- npm run build
- npm audit --omit=dev