### PR TITLE
fix: override postcss audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5148,34 +5148,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "tailwindcss": "4.2.4",
     "tw-animate-css": "1.4.0",
     "typescript": "6.0.3"
+  },
+  "overrides": {
+    "postcss": "8.5.10"
   }
 }


### PR DESCRIPTION
## Summary\n- Add an npm override for PostCSS 8.5.10 so transitive framework copies resolve to the patched version\n- Refresh the package lockfile\n\n## Verification\n- npm audit --production\n- npm run lint\n- npm run build\n\nNote: created from a fresh main clone so the local feature/new-ui worktree stays untouched.