### PR TITLE
Update lucide-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "framer-motion": "12.38.0",
-        "lucide-react": "1.9.0",
+        "lucide-react": "^1.11.0",
         "next": "^16.2.4",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -4957,9 +4957,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.9.0.tgz",
-      "integrity": "sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.11.0.tgz",
+      "integrity": "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -5419,7 +5419,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "framer-motion": "12.38.0",
-    "lucide-react": "1.9.0",
+    "lucide-react": "^1.11.0",
     "next": "^16.2.4",
     "react": "19.2.5",
     "react-dom": "19.2.5",


### PR DESCRIPTION
## Summary
- update lucide-react from 1.9.0 to 1.11.0
- keep the portfolio icon dependency current on the same major version

## Verification
- npm audit --omit=dev
- npm run build