### PR TITLE
fix: enforce WhatsApp challenge validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,16 @@ public/visuals/     # Hero/workbench images and SVGs
 4. About / Operating Style — how David works
 5. Stack — tools he reaches for
 6. Notes / Current Focus — what he's working on now
-7. Contact — WhatsApp-first (WhatsApp, phone, email)
+7. Contact — WhatsApp-first (screened redirect), email, and GitHub
 8. Footer — WhatsApp · Email · GitHub
+
+## Contact protection behavior
+
+- `ProtectedWhatsAppLink` in `components/contact/protected-whatsapp-link.tsx` sets:
+  - a short-lived `dzt-contact-challenge` cookie scoped to `/contact/whatsapp`
+  - a matching `challenge` query param on the outbound link
+- `app/contact/whatsapp/route.ts` validates that cookie/token pairing before issuing the redirect.
+- The route applies light abuse scoring (user-agent quality, referrer, burst patterns, link/spam signals) and returns `403` when blocked.
 
 ## Design / Styling
 - Uses custom `dtz-*` classes defined in `app/globals.css`. Keep this design language: accessible, personal, light/dark, grounded. Not cyberpunk/agency.

--- a/README.md
+++ b/README.md
@@ -53,3 +53,17 @@ public/             # Images, visuals, legacy demos
 
 - The homepage is a personal portfolio, not a router to other sites.
 - Contact is WhatsApp-first (see `data/content.ts` → `contact` / `whatsappHref`), with phone and email as backups.
+
+## Contact protection
+
+This repo keeps the public phone number behind a one-step screened redirect:
+
+- Public buttons point to `/contact/whatsapp`.
+- `/contact/whatsapp` adds `wa.me/<number>?text=...` server-side.
+- A short-lived `dzt-contact-challenge` token/cookie handshake is enforced before redirect.
+- The route includes bot-detection scoring and returns `403` with anti-abuse headers when the handshake or risk checks fail.
+
+If this still gets noisy:
+
+- Keep one clear human handoff before any final commitments.
+- Add a separate disposable number/business forwarding line for broad campaigns if needed.

--- a/app/contact/whatsapp/route.ts
+++ b/app/contact/whatsapp/route.ts
@@ -63,7 +63,7 @@ function parseChallengeValue(value: string | null) {
   const issuedAt = Number.parseInt(issuedAtRaw, 10)
   if (!Number.isFinite(issuedAt) || issuedAt <= 0) return null
 
-  return { token, issuedAt }
+  return { token, issuedAt: issuedAt * 1000 }
 }
 
 function validateContactChallenge(request: NextRequest): ChallengeValidation {
@@ -132,8 +132,10 @@ function scoreRequest(request: NextRequest, text: string): ScoredRequest {
 
   const challenge = validateContactChallenge(request)
   if (!challenge.valid) {
-    score += 2
-    reasons.push(challenge.reason)
+    return {
+      blocked: true,
+      reasons: [challenge.reason ?? "contact-challenge-required"],
+    }
   }
 
   if (text.length > 900) {

--- a/app/contact/whatsapp/route.ts
+++ b/app/contact/whatsapp/route.ts
@@ -62,8 +62,10 @@ function parseChallengeValue(value: string | null) {
 
   const issuedAt = Number.parseInt(issuedAtRaw, 10)
   if (!Number.isFinite(issuedAt) || issuedAt <= 0) return null
+  const issuedAtMs =
+    issuedAtRaw.length >= 13 ? issuedAt : issuedAt * 1000
 
-  return { token, issuedAt: issuedAt * 1000 }
+  return { token, issuedAt: issuedAtMs }
 }
 
 function validateContactChallenge(request: NextRequest): ChallengeValidation {

--- a/docs/contact-intake-spam-guard.md
+++ b/docs/contact-intake-spam-guard.md
@@ -9,6 +9,19 @@ This is the recommended path for protecting David's public phone number while ke
 - The redirect route sends `X-Robots-Tag: noindex,nofollow` so it is not treated as a page to index.
 - The contact section now explains the screened-contact approach instead of presenting the phone number as an open public target.
 - The contact route now requires a strict challenge handshake (issued token + matching cookie), then applies scored abuse checks (user-agent checks, referrer presence, burst-rate window, and suspicious content patterns), sanitizes outbound message text, and returns a `403` blocked response with anti-bot headers when validation fails.
+- The challenge parser accepts both old-second and new-millisecond issued-at values so the route remains compatible with mixed client token formats.
+
+## Current behavior in code
+
+1. Public link is rendered through `ProtectedWhatsAppLink`.
+2. On mount, it generates a random token and timestamp, then stores a browser cookie:
+   - `dzt-contact-challenge=<token>.<issuedAt>` (10-minute TTL)
+3. The link receives the same value as `?challenge=...` and sends the user to `/contact/whatsapp`.
+4. `app/contact/whatsapp/route.ts` validates:
+   - challenge exists,
+   - cookie exists and matches token,
+   - challenge age is within the 10-minute window.
+5. If any check fails, the route responds with `403` and includes `X-Contact-Guard` reason metadata for diagnostics.
 
 This does not make the number impossible to discover. It reduces passive scraping from static homepage HTML and gives us a server route where stronger checks can be added later.
 

--- a/docs/contact-intake-spam-guard.md
+++ b/docs/contact-intake-spam-guard.md
@@ -8,7 +8,7 @@ This is the recommended path for protecting David's public phone number while ke
 - The homepage WhatsApp CTA now points to `/contact/whatsapp`, a local redirect route that adds the real `wa.me` number server-side.
 - The redirect route sends `X-Robots-Tag: noindex,nofollow` so it is not treated as a page to index.
 - The contact section now explains the screened-contact approach instead of presenting the phone number as an open public target.
-- The contact route currently applies a scored anti-abuse check (user agent checks, referrer presence, burst-rate window, and suspicious content patterns), sanitizes outbound message text, and returns a 403 blocked response with anti-bot headers when risk is high.
+- The contact route now requires a strict challenge handshake (issued token + matching cookie), then applies scored abuse checks (user-agent checks, referrer presence, burst-rate window, and suspicious content patterns), sanitizes outbound message text, and returns a `403` blocked response with anti-bot headers when validation fails.
 
 This does not make the number impossible to discover. It reduces passive scraping from static homepage HTML and gives us a server route where stronger checks can be added later.
 
@@ -27,7 +27,7 @@ Use a screened WhatsApp intake bot, not a fully autonomous sales bot.
 
 ## Suggested filters
 
-- Implemented: block/reject when the score crosses threshold (current threshold: 5+), including:
+- Implemented: block/reject for missing/invalid challenge + score-based abuse signals (current scoring includes):
   - missing/short user-agent
   - bot-like automation headers
   - missing referrer / cross-site fetch
@@ -36,6 +36,7 @@ Use a screened WhatsApp intake bot, not a fully autonomous sales bot.
   - repeated word pattern typical in spam generators
   - link-heavy/spam-like message patterns
   - burst traffic from the same IP (60s window)
+  - challenge mismatch/expiry/missing cookie
 - Keep `intent` filtering on `/contact/whatsapp` and reject automation-flood templates.
 - Add a cooldown per sender before sending any automated reply.
 - Keep a manual blocklist and allowlist.


### PR DESCRIPTION
## Why
- Prevents direct WhatsApp redirect bypass when a fabricated challenge token is provided.
- Ensures challenge timestamps are interpreted correctly so valid signed links are not rejected unexpectedly.

## Validation
- npm run lint
- npm run build
- Manual endpoint checks against /contact/whatsapp with missing/invalid/valid challenge-cookies
