### PR TITLE
chore: add fossa scan runbook and dependency triage notes

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -23,6 +23,7 @@ ignore:
       includes MPL text. These are not runtime-modified distributables in this app.
       The app uses Next.js as a dependency and does not redistribute those assets
       as separate business logic.
+      If `next` is upgraded, verify and update this locator before merging.
 
   - type: license
     locator: npm+@vercel/og$0.11.1

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,7 @@
 
 - [ ] `npm run lint`
 - [ ] `npm run build`
+- [ ] If dependency files changed: dependency and FOSSA scan checklist completed
 - [ ] Manual smoke test on key pages (`/`, `/design-system`)
 
 ### Content & Links (if applicable)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,7 +37,7 @@
 - [ ] `npm run lint`
 - [ ] `npm run build`
 - [ ] If dependency files changed: dependency and FOSSA scan checklist completed
-- [ ] Manual smoke test on key pages (`/`, `/design-system`)
+- [ ] Manual smoke test on key pages (`/`, `/contact`, `/portfolio`, `/pay`)
 
 ### Content & Links (if applicable)
 
@@ -49,7 +49,7 @@
 
 - [ ] Prompt/behavior updates tested end-to-end
 - [ ] Rate limiting still enforced
-- [ ] Env vars checked: `OPENROUTER_API_KEY`, `SITE_URL`, `OPENROUTER_PRIMARY_MODEL`
+- [ ] Env vars checked: `OPENROUTER_API_KEY`, `SITE_URL`, `OPENROUTER_MODELS` / `OPENROUTER_MODEL`
 
 ### Assets & Branding (if applicable)
 

--- a/README.md
+++ b/README.md
@@ -67,3 +67,10 @@ If this still gets noisy:
 
 - Keep one clear human handoff before any final commitments.
 - Add a separate disposable number/business forwarding line for broad campaigns if needed.
+
+## Dependency and supply-chain checks
+
+If you touch dependencies or `.fossa.yml`, follow the documented scan workflow before merge:
+
+- `docs/fossa-scan-playbook.md`
+- `docs/fossa-remediation-notes.md`

--- a/README.md
+++ b/README.md
@@ -72,5 +72,5 @@ If this still gets noisy:
 
 If you touch dependencies or `.fossa.yml`, follow the documented scan workflow before merge:
 
-- `docs/fossa-scan-playbook.md`
-- `docs/fossa-remediation-notes.md`
+- [FOSSA scan playbook](docs/fossa-scan-playbook.md)
+- [FOSSA remediation notes](docs/fossa-remediation-notes.md)

--- a/docs/fossa-remediation-notes.md
+++ b/docs/fossa-remediation-notes.md
@@ -1,43 +1,49 @@
 # FOSSA Remediation Notes
 
-Latest reviewed PR commit: `458d829`
+Latest reviewed PR commit: `11c6fa2`
 
 ## Current Status
 
 - Vercel preview: passing
 - FOSSA Security Analysis: passing
-- FOSSA Dependency Quality: active (major-version refresh for Next remains outstanding)
-- FOSSA License Compliance: active (scan-level ignore entries now tracked in `.fossa.yml`)
+- FOSSA Dependency Quality: active (manual review remains for `next` major-version drift)
+- FOSSA License Compliance: active (non-blocking licenses are documented and tracked in `.fossa.yml`)
 
-The previous branch-level pass reduced the public FOSSA scan from `60` issues and `553` dependencies on `main` to `28` issues and `433` dependencies on the prior branch scan.
+## Known Scanner State
 
-Latest scan snapshot includes two new high-signal findings:
+- `next@16.2.7` shows artifact license matches:
+  - `CC-BY-SA-4.0` (`next/dist/compiled/glob/LICENSE`)
+  - `MPL-2.0` (`dist/compiled/@vercel/og/package.json`)
+- `brace-expansion` appears as transitive at `2.1.1` via transitive `@typescript-eslint`/`eslint` chains.
+- FOSSA policy still flags `next` as older than current upstream.
 
-- `next@16.2.7` flagged with `CC-BY-SA-4.0` from `next/dist/compiled/glob/LICENSE`.
-- `next@16.2.7` flagged with `MPL-2.0` from `dist/compiled/@vercel/og/package.json`.
+These findings are tracked as non-blocking in `.fossa.yml` while we preserve stack stability.
 
-These are now documented and guarded in `.fossa.yml` so they do not block dependency work while we keep the current Next.js stack stable.
+## Recent Repo-Side Work
 
-## Repo-Side Work Completed
-
-- Added `.fossa.yml` with project-level license scan ignore rules for:
-  - `next@16.2.7` (`CC-BY-SA-4.0`, `MPL-2.0`) artifact findings.
-  - `@vercel/og@0.11.1` (`MPL-2.0`) artifact findings.
-- Updated `@types/node` to `^25.9.2` to remove the direct version-age warning (`22.19.20` -> `25.9.2`).
-- Kept `next` and ESLint stack versions stable to avoid framework/compile regressions.
-- Kept a short-lived phone contact hardening route as the first public contact path; no direct `tel:`/`wa.me` link exposure.
+- Added/kept `.fossa.yml` ignore entries for the Next.js internal license findings:
+  - `next@16.2.7` (`CC-BY-SA-4.0`, `MPL-2.0`)
+  - `@vercel/og@0.11.1` (`MPL-2.0`)
+- Upgraded `@types/node` to `^25.9.2` (the direct dependency age warning at `22.19.20` is no longer active).
+- Kept the phone-contact hardening path as the first public contact mechanism; no bare `tel:` or direct `wa.me` links are rendered on public pages.
 - Verified:
   - `npm run lint`
   - `npm run build`
 
-## Remaining Known Findings / Non-Blocking Items
+## Future Scan Controls
 
-- `@types/node` in direct dependency list is now current (resolved).
-- `brace-expansion` still appears at `2.1.1` through `@types`/ESLint transitive chains; a clean migration to a newer major requires a broader toolchain bump.
-- `next` direct dependency is still behind upstream major releases; no safe in-repo upgrade path identified without broad testing.
+- Before any dependency update PR, refresh the local dependency scan context and compare this file with the live FOSSA scan.
+- If a previously ignored issue disappears or changes locator/version, update `.fossa.yml` first and then verify the scan.
+- Treat any new dependency issue that is not covered by this document as blocking until reviewed.
+- A full dependency jump plan (including `next` and `eslint` stack refresh risk) is tracked in `docs/fossa-scan-playbook.md`.
 
 ## Relevant FOSSA References
 
-- Ignoring a Dependency: https://docs.fossa.com/docs/ignoring-a-dependency
-- Reviewing Licensing Issues: https://docs.fossa.com/docs/reviewing-licensing-issues
-- Ignoring Open Source Package Issues: https://docs.fossa.com/docs/ignoring-open-source-package-issues
+- [Ignoring a Dependency](https://docs.fossa.com/docs/ignoring-a-dependency)
+- [Reviewing Licensing Issues](https://docs.fossa.com/docs/reviewing-licensing-issues)
+- [Ignoring Open Source Package Issues](https://docs.fossa.com/docs/ignoring-open-source-package-issues)
+
+## Out-of-Date Item Check (Quick)
+
+- `next@16.2.7` is intentionally held stable until a broader framework upgrade is scheduled.
+- `brace-expansion@2.1.1` is transitive and currently accepted for this project’s current lint/toolchain matrix.

--- a/docs/fossa-remediation-notes.md
+++ b/docs/fossa-remediation-notes.md
@@ -13,7 +13,7 @@ Latest reviewed PR commit: `11c6fa2`
 
 - `next@16.2.7` shows artifact license matches:
   - `CC-BY-SA-4.0` (`next/dist/compiled/glob/LICENSE`)
-  - `MPL-2.0` (`dist/compiled/@vercel/og/package.json`)
+  - `MPL-2.0` (`next/dist/compiled/@vercel/og/package.json`)
 - `brace-expansion` appears as transitive at `2.1.1` via transitive `@typescript-eslint`/`eslint` chains.
 - FOSSA policy still flags `next` as older than current upstream.
 

--- a/docs/fossa-scan-playbook.md
+++ b/docs/fossa-scan-playbook.md
@@ -6,7 +6,7 @@ Goal: keep dependency scans predictable, keep useful findings reviewable, and av
 
 - `next@16.2.7`
   - `CC-BY-SA-4.0` in `next/dist/compiled/glob/LICENSE`
-  - `MPL-2.0` in `dist/compiled/@vercel/og/package.json`
+  - `MPL-2.0` in `next/dist/compiled/@vercel/og/package.json`
   - Tracked in `.fossa.yml` as non-blocking
 - `brace-expansion@2.1.1`
   - Transitive via `@typescript-eslint`/`eslint`

--- a/docs/fossa-scan-playbook.md
+++ b/docs/fossa-scan-playbook.md
@@ -1,0 +1,54 @@
+# FOSSA Scan Playbook (Portfolio Repo)
+
+Goal: keep dependency scans predictable, keep useful findings reviewable, and avoid losing track after dependency churn.
+
+## Current known accepted issues
+
+- `next@16.2.7`
+  - `CC-BY-SA-4.0` in `next/dist/compiled/glob/LICENSE`
+  - `MPL-2.0` in `dist/compiled/@vercel/og/package.json`
+  - Tracked in `.fossa.yml` as non-blocking
+- `brace-expansion@2.1.1`
+  - Transitive via `@typescript-eslint`/`eslint`
+  - Accepted without framework bump for now
+
+If any of the above changes locator/version on future scans, update:
+
+- `.fossa.yml` first (locator/versions)
+- `docs/fossa-remediation-notes.md`
+- PR notes/changelog for this scan change
+
+## Pre-merge dependency check
+
+Run before opening PRs that touch:
+
+- `package.json`
+- `package-lock.json`
+- `.fossa.yml`
+
+1. `npm install`
+2. `npm run lint`
+3. `npm run build`
+4. Re-check dependency state:
+   ```bash
+   npm outdated --json
+   npm ls brace-expansion
+   ```
+5. Re-run/trigger the FOSSA scan for this branch.
+6. In FOSSA, resolve scan findings with this rule:
+   - **Existing expected issue + no location/version change**: no action except adding scan run timestamp in PR notes
+   - **Existing expected issue + new locator/version**: update ignore + docs in the same PR
+   - **Any new denied security issue**: block merge until remediated
+   - **Any new denied license issue**: block unless legally reviewed and intentionally risk-accepted
+
+## Quarterly hygiene
+
+- Confirm `fossa-remediation-notes.md` still reflects the current active findings.
+- Review whether the accepted findings are still acceptable for your intended distribution model.
+- Add a ticket for intentional `next`/`eslint` toolchain refresh when business risk allows a framework upgrade window.
+
+## Useful reference links
+
+- [Ignoring a dependency](https://docs.fossa.com/docs/ignoring-a-dependency)
+- [Ignoring open source package issues](https://docs.fossa.com/docs/ignoring-open-source-package-issues)
+- [Reviewing licensing issues](https://docs.fossa.com/docs/reviewing-licensing-issues)


### PR DESCRIPTION
## Why
This follow-up keeps FOSSA remediation handling non-regressing after the merge.

## What changed
- refreshed FOSSA notes with current merge reference and active findings
- added a FOSSA scan playbook for dependency-change gating
- added PR template reminder for dependency/FOSSA checklist completion
- added README note linking the scan playbook and remediation notes
- kept `.fossa.yml` clear about locator updates when upgrading `next`

## Verification
- `npm run lint`
- `npm run build`
