### PR TITLE
fix: /contact/whatsapp 500 (undefined CONTACT_PATH) + enable type checks

### DIFF
--- a/app/contact/whatsapp/route.ts
+++ b/app/contact/whatsapp/route.ts
@@ -30,6 +30,10 @@ const suspiciousTextPatterns = [
 const repeatedWordPattern = /\b([A-Za-zÀ-ÿ']{2,})\b(?:\s+\1){2,}/i
 
 const contactChallengeCookieName = "dzt-contact-challenge"
+// Must match the Path used by ProtectedWhatsAppLink when it SETS the cookie
+// (components/contact/protected-whatsapp-link.tsx) so the Max-Age=0 clear below
+// actually targets the same cookie. A mismatch silently fails to clear it.
+const CONTACT_PATH = "/contact/whatsapp"
 const contactChallengeWindowMs = 10 * 60_000
 const rateBuckets = new Map<string, number[]>()
 const bucketWindowMs = 60_000

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,9 @@
 const nextConfig = {
   allowedDevOrigins: ['127.0.0.1'],
   typescript: {
-    ignoreBuildErrors: true,
+    // Type errors fail the build. Previously `true`, which hid the CONTACT_PATH
+    // ReferenceError fixed in this PR. `tsc --noEmit` is clean as of this change.
+    ignoreBuildErrors: false,
   },
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary

Fixes a **live HTTP 500 on the happy path of `/contact/whatsapp`** (the screened WhatsApp redirect — the one genuinely live user-facing contact feature), and turns on the build-time type check that would have caught it.

## The bug

`markChallengeCookieConsumed()` references `CONTACT_PATH` to scope the `Max-Age=0` cookie clear, but the constant was **never defined in the module**. On a valid (non-blocked) request, `GET` reaches that call and throws `ReferenceError: CONTACT_PATH is not defined`. There's no try/catch in `GET`, so the route returns **500** instead of redirecting to `wa.me`.

Why it went unnoticed:
- `typescript.ignoreBuildErrors: true` suppressed the undefined-reference error at build time.
- It only fires on the **success** path; blocked/spam requests short-circuit earlier.

## The fix (2 commits)

1. **Define `CONTACT_PATH = "/contact/whatsapp"`** — matching the `Path` that `ProtectedWhatsAppLink` (`components/contact/protected-whatsapp-link.tsx:8`) uses when it **sets** the cookie. This matters beyond silencing the error: a cookie can only be cleared with the same `Path` it was set with.
2. **`ignoreBuildErrors: false`** — the guardrail that would have caught this. Verified safe: with `CONTACT_PATH` defined, `tsc --noEmit` reports **zero** errors across the repo and `npm run build` succeeds with type-checking enabled.

## Verification

- `npx tsc --noEmit` → clean (0 errors) on this branch.
- `npm run build` → succeeds with type validation **on**.
- Recommended manual check before merge: open `/contact`, click the WhatsApp link, confirm it 302-redirects to `wa.me` (previously 500) and the `dzt-contact-challenge` cookie is cleared after use.

## Related

Found while mapping the project (see PR #53 + `docs/PROJECT-STRUCTURE.md`, follow-ups #1 and #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
