### PR TITLE
ci: lint/build/test + CodeQL workflows; remove stale vercel.json /projects rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 # Cancel superseded runs on the same ref to save minutes.
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref to save minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      # --if-present so this is a no-op until the test script lands (PR #56),
+      # then runs the Vitest suite automatically once merged.
+      - name: Test
+        run: npm test --if-present
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan (Mondays) to catch advisories on unchanged code.
+    - cron: '23 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,5 @@
   "buildCommand": "npm run build",
   "devCommand": "npm run dev",
   "installCommand": "npm install",
-  "framework": "nextjs",
-  "rewrites": [
-    {
-      "source": "/projects/:slug",
-      "destination": "/projects/:slug/index.html"
-    }
-  ]
+  "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary

Two repo-hygiene fixes surfaced while mapping the project.

### 1. Add CI and CodeQL
The overhaul deleted every workflow in `.github/workflows/`, so nothing runs on push/PR today. Adds a minimal `CI` workflow on Node 20:

```
npm ci → npm run lint → npm test --if-present → npm run build
```

- `--if-present` means the test step is a **no-op until PR #56 lands** (which adds the `test` script), then runs the Vitest suite automatically once merged — no ordering dependency between PRs.
- `permissions: contents: read` scopes the default `GITHUB_TOKEN` to least privilege for CI.
- `concurrency` cancels superseded runs on the same ref.

Also adds a CodeQL JavaScript/TypeScript workflow with `security-and-quality` queries and a weekly scheduled scan.

### 2. Remove the stale `vercel.json` `/projects` rewrite
`vercel.json` rewrote this app's `/projects/:slug → /projects/:slug/index.html`, but this repo has no tracked `public/projects/*` static demo files. Portfolio links that include `/projects/...` point at the external business site via `businessSiteUrl`, not at this repo's local static assets, so the Vercel rewrite was stale.

No `/demo` rewrite added: the replacement `public/demo/*.html` files are served directly by Next, and nothing in source links to them — adding a rewrite would be guessing.

## Notes
- CI `npm run build` runs without secrets (the build doesn't execute route handlers); confirmed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)