### PR TITLE
fix: middleware on /api/chat + doppler project scope

### DIFF
--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,2 +1,2 @@
-project: local-mac-work
-config: dev_personal
+project: david-ortiz-portfolio
+config: dev

--- a/proxy.ts
+++ b/proxy.ts
@@ -20,6 +20,6 @@ export function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!api/chat|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)",
+    "/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)",
   ],
 }


### PR DESCRIPTION
Two small corrections from the project Q&A:

- **proxy.ts** now runs the middleware on /api/chat (removed the unintentional carve-out), so the www to apex 308 canonicalization applies consistently like every other route. Same-origin calls from davidtiz.com are unaffected; only www requests redirect.
- **doppler.yaml** now points at project david-ortiz-portfolio / config dev instead of the personal-scope local-mac-work / dev_personal, so doppler run resolves this project's secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)