### PR TITLE
feat: rate-limit /api/chat + configurable cheap-model fallback chain

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -77,6 +77,15 @@ function getModelChain(): string[] {
 const MAX_MESSAGES = 50
 const MAX_TOTAL_CHARS = 8000
 
+function isChatMessage(value: unknown): value is ChatMessage {
+  if (!value || typeof value !== "object") return false
+  const message = value as Partial<ChatMessage>
+  return (
+    typeof message.content === "string" &&
+    (message.role === "user" || message.role === "assistant" || message.role === "system")
+  )
+}
+
 export async function POST(request: NextRequest) {
   try {
     // Reject the cheap way first, before parsing or calling OpenRouter.
@@ -88,18 +97,27 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const { messages } = (await request.json()) as { messages: ChatMessage[] }
+    let payload: unknown
+    try {
+      payload = await request.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 })
+    }
 
-    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+    const messagesValue =
+      payload && typeof payload === "object" ? (payload as { messages?: unknown }).messages : undefined
+
+    if (!Array.isArray(messagesValue) || messagesValue.length === 0) {
       return NextResponse.json({ error: "Messages array is required" }, { status: 400 })
     }
+    if (!messagesValue.every(isChatMessage)) {
+      return NextResponse.json({ error: "Invalid messages format" }, { status: 400 })
+    }
+    const messages = messagesValue as ChatMessage[]
     if (messages.length > MAX_MESSAGES) {
       return NextResponse.json({ error: "Too many messages" }, { status: 400 })
     }
-    const totalChars = messages.reduce(
-      (n, m) => n + (typeof m?.content === "string" ? m.content.length : 0),
-      0,
-    )
+    const totalChars = messages.reduce((n, m) => n + m.content.length, 0)
     if (totalChars > MAX_TOTAL_CHARS) {
       return NextResponse.json({ error: "Message content too long" }, { status: 400 })
     }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -26,80 +26,149 @@ interface ChatMessage {
   content: string
 }
 
+// --- Rate limiting -----------------------------------------------------------
+// Per-IP sliding window. In-memory (per serverless instance, resets on cold
+// start) so it is best-effort, not a hard global guarantee — but it caps the
+// obvious abuse case (one client hammering the endpoint and billing the key).
+const CHAT_RATE_LIMIT = { windowMs: 60_000, maxRequests: 15 }
+const chatRateBuckets = new Map<string, number[]>()
+
+function getClientIp(request: NextRequest) {
+  return (
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown"
+  )
+}
+
+function rateLimit(ip: string) {
+  const now = Date.now()
+  const windowStart = now - CHAT_RATE_LIMIT.windowMs
+  const recent = (chatRateBuckets.get(ip) ?? []).filter((t) => t > windowStart)
+  if (recent.length >= CHAT_RATE_LIMIT.maxRequests) {
+    return {
+      allowed: false as const,
+      retryAfter: Math.ceil((recent[0] + CHAT_RATE_LIMIT.windowMs - now) / 1000),
+    }
+  }
+  recent.push(now)
+  chatRateBuckets.set(ip, recent)
+  return { allowed: true as const }
+}
+
+// --- Model selection ---------------------------------------------------------
+// Cheapest-first fallback chain, fully overridable via env:
+//   OPENROUTER_MODELS = comma-separated chain, tried in order (preferred)
+//   OPENROUTER_MODEL  = single model (back-compat)
+// Default is `openrouter/free`, OpenRouter's auto-router over free models —
+// cheapest possible and self-maintaining as specific free model ids change.
+const DEFAULT_MODELS = ["openrouter/free"]
+
+function getModelChain(): string[] {
+  const list = process.env.OPENROUTER_MODELS?.split(",").map((m) => m.trim()).filter(Boolean)
+  if (list && list.length > 0) return list
+  const single = process.env.OPENROUTER_MODEL?.trim()
+  if (single) return [single]
+  return DEFAULT_MODELS
+}
+
+// --- Payload guards ----------------------------------------------------------
+const MAX_MESSAGES = 50
+const MAX_TOTAL_CHARS = 8000
+
 export async function POST(request: NextRequest) {
   try {
-    const { messages } = await request.json() as { messages: ChatMessage[] }
-
-    if (!messages || !Array.isArray(messages)) {
+    // Reject the cheap way first, before parsing or calling OpenRouter.
+    const limit = rateLimit(getClientIp(request))
+    if (!limit.allowed) {
       return NextResponse.json(
-        { error: "Messages array is required" },
-        { status: 400 }
+        { error: "Too many requests", retryAfter: limit.retryAfter },
+        { status: 429, headers: { "Retry-After": String(limit.retryAfter) } },
       )
     }
 
-    const apiKey = process.env.OPENROUTER_API_KEY
-    const model = process.env.OPENROUTER_MODEL || "google/gemini-3.1-flash-lite"
+    const { messages } = (await request.json()) as { messages: ChatMessage[] }
 
+    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+      return NextResponse.json({ error: "Messages array is required" }, { status: 400 })
+    }
+    if (messages.length > MAX_MESSAGES) {
+      return NextResponse.json({ error: "Too many messages" }, { status: 400 })
+    }
+    const totalChars = messages.reduce(
+      (n, m) => n + (typeof m?.content === "string" ? m.content.length : 0),
+      0,
+    )
+    if (totalChars > MAX_TOTAL_CHARS) {
+      return NextResponse.json({ error: "Message content too long" }, { status: 400 })
+    }
+
+    const apiKey = process.env.OPENROUTER_API_KEY
     if (!apiKey) {
       console.error("OPENROUTER_API_KEY not configured")
       return NextResponse.json({
         message: getFallbackResponse(messages[messages.length - 1]?.content || ""),
-        fallback: true
+        fallback: true,
       })
     }
 
     const apiMessages: ChatMessage[] = [
       { role: "system", content: SYSTEM_PROMPT },
-      ...messages.slice(-10)
+      ...messages.slice(-10),
     ]
 
-    const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-        "HTTP-Referer": process.env.SITE_URL || "https://davidtiz.com",
-        "X-Title": "David Ortiz AI Assistant"
-      },
-      body: JSON.stringify({
-        model,
-        messages: apiMessages,
-        max_tokens: 220,
-        temperature: 0.35,
-        provider: {
-          sort: "price",
-          allow_fallbacks: true,
-        },
-      })
-    })
+    // Try each model in the chain until one returns usable content.
+    let lastError: string | null = null
+    for (const model of getModelChain()) {
+      try {
+        const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+            "HTTP-Referer": process.env.SITE_URL || "https://davidtiz.com",
+            "X-Title": "David Ortiz AI Assistant",
+          },
+          body: JSON.stringify({
+            model,
+            messages: apiMessages,
+            max_tokens: 220,
+            temperature: 0.35,
+            provider: {
+              sort: "price",
+              allow_fallbacks: true,
+            },
+          }),
+        })
 
-    if (!response.ok) {
-      const errorData = await response.text()
-      console.error("OpenRouter API error:", response.status, errorData)
+        if (!response.ok) {
+          lastError = `model ${model} -> ${response.status}`
+          console.error("OpenRouter API error:", lastError, await response.text().catch(() => ""))
+          continue
+        }
 
-      return NextResponse.json({
-        message: getFallbackResponse(messages[messages.length - 1]?.content || ""),
-        fallback: true
-      })
+        const data = await response.json()
+        const assistantMessage = data.choices?.[0]?.message?.content
+        if (typeof assistantMessage === "string" && assistantMessage.length > 0) {
+          return NextResponse.json({ message: assistantMessage, fallback: false })
+        }
+        lastError = `model ${model} returned empty content`
+      } catch (error) {
+        lastError = `model ${model} threw: ${error instanceof Error ? error.message : "unknown"}`
+        console.error(lastError)
+      }
     }
 
-    const data = await response.json()
-    const assistantMessage = data.choices?.[0]?.message?.content
-
-    if (!assistantMessage) {
-      throw new Error("No response from AI")
-    }
-
+    // Every model failed — degrade gracefully instead of erroring.
+    console.error("All chat models failed:", lastError)
     return NextResponse.json({
-      message: assistantMessage,
-      fallback: false
+      message: getFallbackResponse(messages[messages.length - 1]?.content || ""),
+      fallback: true,
     })
   } catch (error) {
     console.error("Chat API error:", error)
-    return NextResponse.json(
-      { error: "Failed to process chat request" },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: "Failed to process chat request" }, { status: 500 })
   }
 }
 


### PR DESCRIPTION
Addresses cost-abuse risk (Q1) and the cheap-model preference (Q4) — both for the endpoint that bills your OpenRouter key.

## Rate limiting (Q1 — wasn't intentional to omit)
- Per-IP sliding window, **15 req/min** → **429** with Retry-After, checked **before** parsing or calling OpenRouter.
- Payload guards: reject empty / >50 messages / >8000 total chars → **400**.

## Cheap models (Q4)
Model selection is now a **cheapest-first fallback chain**, fully env-driven:
- `OPENROUTER_MODELS` — comma-separated chain, tried in order (preferred)
- `OPENROUTER_MODEL` — single model (back-compat)
- default `openrouter/free` — OpenRouter's **free auto-router**, cheapest possible and self-maintaining as specific free model ids change.

Tries each model until one returns content, keeps `provider.sort: price`, and still **degrades gracefully** to the canned keyword response if all models fail or the key is missing.

## ⚙️ Action for you
To get off `google/gemini-3.1-flash-lite`: either set `OPENROUTER_MODELS` in Doppler to your preferred cheap chain, **or unset `OPENROUTER_MODEL`** so it defaults to the free auto-router. (If `OPENROUTER_MODEL` is currently set to the gemini model, it'll keep using it until you change it.)

## Notes
- New **429** status: the AI-assistant UI (to be re-added per Q9) should handle it.
- No unit test here — the Vitest infra lands in PR #56; a `/api/chat` spec (rate-limit + caps + fallback) is the natural follow-up once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)