### PR TITLE
feat: HttpOnly contact-challenge cookie (server-side issuance) — Q2

### DIFF
--- a/app/contact/whatsapp/challenge/route.test.ts
+++ b/app/contact/whatsapp/challenge/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { NextRequest } from "next/server"
+import { GET } from "@/app/contact/whatsapp/challenge/route"
+
+const URL = "https://davidtiz.com/contact/whatsapp/challenge"
+
+describe("GET /contact/whatsapp/challenge", () => {
+  it("returns a token and sets a matching HttpOnly challenge cookie", async () => {
+    const res = GET(new NextRequest(URL))
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.token).toMatch(/^[a-f0-9]{32}\.\d+$/)
+
+    const setCookie = res.headers.get("set-cookie") ?? ""
+    expect(setCookie).toContain(`dzt-contact-challenge=${body.token}`)
+    expect(setCookie).toContain("HttpOnly")
+    expect(setCookie).toContain("Path=/contact/whatsapp")
+    expect(setCookie).toContain("SameSite=Lax")
+  })
+
+  it("marks the token response no-store so tokens are never cached", () => {
+    const res = GET(new NextRequest(URL))
+    expect(res.headers.get("cache-control")).toBe("no-store")
+  })
+
+  it("sets the Secure attribute over https", () => {
+    const res = GET(new NextRequest(URL))
+    expect(res.headers.get("set-cookie") ?? "").toContain("Secure")
+  })
+
+  it("mints a unique token per request", async () => {
+    const a = await GET(new NextRequest(URL)).json()
+    const b = await GET(new NextRequest(URL)).json()
+    expect(a.token).not.toBe(b.token)
+  })
+})

--- a/app/contact/whatsapp/challenge/route.ts
+++ b/app/contact/whatsapp/challenge/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server"
+import { randomBytes } from "node:crypto"
+
+export const runtime = "nodejs"
+
+const CHALLENGE_COOKIE_NAME = "dzt-contact-challenge"
+const CHALLENGE_COOKIE_PATH = "/contact/whatsapp"
+const CHALLENGE_TTL_SECONDS = 10 * 60
+
+// Issues a single-use contact challenge. The token is returned to the caller
+// (so it can be echoed back as the `?challenge=` query param on the outbound
+// link) AND set as a cookie server-side. The cookie is HttpOnly so client JS
+// can neither read nor forge it; the redirect route (/contact/whatsapp) then
+// compares the cookie token against the query token. Minting and validation
+// are both server-side now, which also removes the old client/server clock-skew
+// failure mode on the expiry check.
+export function GET(request: NextRequest) {
+  const token = `${randomBytes(16).toString("hex")}.${Date.now()}`
+  const secure = request.nextUrl.protocol === "https:" ? "; Secure" : ""
+
+  const response = NextResponse.json(
+    { token, expiresIn: CHALLENGE_TTL_SECONDS },
+    { headers: { "Cache-Control": "no-store" } },
+  )
+
+  response.headers.append(
+    "Set-Cookie",
+    `${CHALLENGE_COOKIE_NAME}=${token}; Path=${CHALLENGE_COOKIE_PATH}; Max-Age=${CHALLENGE_TTL_SECONDS}; SameSite=Lax; HttpOnly${secure}`,
+  )
+
+  return response
+}

--- a/app/contact/whatsapp/challenge/route.ts
+++ b/app/contact/whatsapp/challenge/route.ts
@@ -16,17 +16,19 @@ const CHALLENGE_TTL_SECONDS = 10 * 60
 // failure mode on the expiry check.
 export function GET(request: NextRequest) {
   const token = `${randomBytes(16).toString("hex")}.${Date.now()}`
-  const secure = request.nextUrl.protocol === "https:" ? "; Secure" : ""
 
   const response = NextResponse.json(
     { token, expiresIn: CHALLENGE_TTL_SECONDS },
     { headers: { "Cache-Control": "no-store" } },
   )
 
-  response.headers.append(
-    "Set-Cookie",
-    `${CHALLENGE_COOKIE_NAME}=${token}; Path=${CHALLENGE_COOKIE_PATH}; Max-Age=${CHALLENGE_TTL_SECONDS}; SameSite=Lax; HttpOnly${secure}`,
-  )
+  response.cookies.set(CHALLENGE_COOKIE_NAME, token, {
+    path: CHALLENGE_COOKIE_PATH,
+    maxAge: CHALLENGE_TTL_SECONDS,
+    sameSite: "lax",
+    httpOnly: true,
+    secure: request.nextUrl.protocol === "https:",
+  })
 
   return response
 }

--- a/app/contact/whatsapp/route.ts
+++ b/app/contact/whatsapp/route.ts
@@ -243,7 +243,7 @@ function markChallengeCookieConsumed(response: NextResponse, request: NextReques
   const secure = request.nextUrl.protocol === "https:" ? "; Secure" : ""
   response.headers.append(
     "Set-Cookie",
-    `${contactChallengeCookieName}=; Path=${CONTACT_PATH}; Max-Age=0; SameSite=Lax${secure}`
+    `${contactChallengeCookieName}=; Path=${CONTACT_PATH}; Max-Age=0; SameSite=Lax; HttpOnly${secure}`
   )
 }
 

--- a/components/contact/protected-whatsapp-link.tsx
+++ b/components/contact/protected-whatsapp-link.tsx
@@ -3,31 +3,40 @@
 import type { AnchorHTMLAttributes, ReactNode } from "react"
 import { useEffect, useState } from "react"
 
-const CHALLENGE_COOKIE_NAME = "dzt-contact-challenge"
-const CHALLENGE_TTL_SECONDS = 10 * 60
 const CONTACT_PATH = "/contact/whatsapp"
+const CHALLENGE_ENDPOINT = "/contact/whatsapp/challenge"
+
+// One challenge per page load, shared across every link instance. The server
+// issues a single HttpOnly cookie, so all links must echo the SAME token for
+// the cookie/query match to succeed — sharing the promise both avoids N
+// redundant requests and prevents instances from overwriting each other's
+// cookie (only the last writer would otherwise have matched).
+let sharedChallenge: Promise<string | null> | null = null
+
+function requestChallenge(): Promise<string | null> {
+  if (!sharedChallenge) {
+    sharedChallenge = fetch(CHALLENGE_ENDPOINT, {
+      method: "GET",
+      credentials: "same-origin",
+      headers: { accept: "application/json" },
+    })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data) => (typeof data?.token === "string" ? data.token : null))
+      .catch(() => null)
+  }
+  return sharedChallenge
+}
 
 type ProtectedWhatsAppLinkProps = {
   href: string
   children: ReactNode
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "children">
 
-function randomHex(length: number) {
-  const bytes = new Uint8Array(length)
-  crypto.getRandomValues(bytes)
-  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")
-}
-
 function addChallenge(href: string, challenge: string) {
   const url = new URL(href, window.location.origin)
   url.searchParams.delete("challenge")
   url.searchParams.set("challenge", challenge)
   return `${url.pathname}${url.search}${url.hash}`
-}
-
-function setChallengeCookie(challenge: string) {
-  const secure = window.location.protocol === "https:" ? "; Secure" : ""
-  document.cookie = `${CHALLENGE_COOKIE_NAME}=${encodeURIComponent(challenge)}; Path=${CONTACT_PATH}; Max-Age=${CHALLENGE_TTL_SECONDS}; SameSite=Lax${secure}`
 }
 
 export function ProtectedWhatsAppLink({
@@ -38,20 +47,19 @@ export function ProtectedWhatsAppLink({
   const [finalHref, setFinalHref] = useState(href)
 
   useEffect(() => {
-  if (!href.startsWith(CONTACT_PATH)) {
+    if (!href.startsWith(CONTACT_PATH)) {
       return
     }
 
-    const token = `${randomHex(16)}.${Date.now()}`
-    const nextHref = addChallenge(href, token)
-
-    const timer = window.setTimeout(() => {
-      setChallengeCookie(token)
-      setFinalHref(nextHref)
-    }, 0)
+    let active = true
+    requestChallenge().then((token) => {
+      if (active && token) {
+        setFinalHref(addChallenge(href, token))
+      }
+    })
 
     return () => {
-      window.clearTimeout(timer)
+      active = false
     }
   }, [href])
 


### PR DESCRIPTION
Makes the `dzt-contact-challenge` cookie **HttpOnly** (Q2). Since JS can't set HttpOnly cookies, challenge issuance moves server-side.

## Change
- **New `GET /contact/whatsapp/challenge`** mints the token, returns it (so it can be echoed as the `?challenge=` query param), and sets the cookie server-side: **HttpOnly + SameSite=Lax + Secure (https) + Max-Age 600**, response marked `no-store`. Client JS can no longer read or forge the cookie.
- **`ProtectedWhatsAppLink`** now fetches **one shared challenge per page load** instead of generating its own token + writing the cookie via `document.cookie`.
- **`markChallengeCookieConsumed`** clears the cookie with HttpOnly too.
- The validation flow in `/contact/whatsapp` is **unchanged** (query-token vs cookie-token match, age, replay, abuse scoring).

## Bonus fix
The old client set the single cookie from *each* link instance, so with multiple WhatsApp links on a page only the **last writer's** token matched the cookie — the others would have failed validation. Sharing one challenge fixes that. Minting + validating are now both server-side, which also removes the prior **client/server clock-skew** risk on the expiry check.

## Review follow-up
- Switched challenge issuance to `response.cookies.set(...)` instead of manually appending the `Set-Cookie` string.

## Tests
Adds 4 specs for the issuance route (token format, HttpOnly/Path/SameSite/Secure cookie, `no-store`, per-request uniqueness). **19 tests pass**, lint + build clean, new route registers in the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)