### PR TITLE
test: cover /api/chat guards + /contact/whatsapp challenge/replay flow

### DIFF
--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { NextRequest } from "next/server"
 
-const URL = "https://davidtiz.com/api/chat"
+const URL = "https://example.com/api/chat"
 const validBody = { messages: [{ role: "user", content: "hi" }] }
 
 function post(body: unknown, headers: Record<string, string> = {}) {
@@ -30,17 +30,15 @@ describe("POST /api/chat — validation (rejects before any model call)", () => 
   })
 
   it("400 when messages is missing or empty", async () => {
-    const a = await loadRoute()
-    expect((await a.POST(post({}))).status).toBe(400)
-    const b = await loadRoute()
-    expect((await b.POST(post({ messages: [] }))).status).toBe(400)
+    const { POST } = await loadRoute()
+    expect((await POST(post({}))).status).toBe(400)
+    expect((await POST(post({ messages: [] }))).status).toBe(400)
   })
 
   it("400 when a message has an invalid role or non-string content", async () => {
-    const a = await loadRoute()
-    expect((await a.POST(post({ messages: [{ role: "bot", content: "x" }] }))).status).toBe(400)
-    const b = await loadRoute()
-    expect((await b.POST(post({ messages: [{ role: "user", content: 123 }] }))).status).toBe(400)
+    const { POST } = await loadRoute()
+    expect((await POST(post({ messages: [{ role: "bot", content: "x" }] }))).status).toBe(400)
+    expect((await POST(post({ messages: [{ role: "user", content: 123 }] }))).status).toBe(400)
   })
 
   it("400 over the message-count cap (50)", async () => {

--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+const URL = "https://davidtiz.com/api/chat"
+const validBody = { messages: [{ role: "user", content: "hi" }] }
+
+function post(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest(URL, {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: { "content-type": "application/json", ...headers },
+  })
+}
+
+// Fresh module per test => fresh in-memory rate-limit bucket.
+async function loadRoute() {
+  vi.resetModules()
+  return import("@/app/api/chat/route")
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe("POST /api/chat — validation (rejects before any model call)", () => {
+  it("400 on invalid JSON", async () => {
+    const { POST } = await loadRoute()
+    expect((await POST(post("{ not json"))).status).toBe(400)
+  })
+
+  it("400 when messages is missing or empty", async () => {
+    const a = await loadRoute()
+    expect((await a.POST(post({}))).status).toBe(400)
+    const b = await loadRoute()
+    expect((await b.POST(post({ messages: [] }))).status).toBe(400)
+  })
+
+  it("400 when a message has an invalid role or non-string content", async () => {
+    const a = await loadRoute()
+    expect((await a.POST(post({ messages: [{ role: "bot", content: "x" }] }))).status).toBe(400)
+    const b = await loadRoute()
+    expect((await b.POST(post({ messages: [{ role: "user", content: 123 }] }))).status).toBe(400)
+  })
+
+  it("400 over the message-count cap (50)", async () => {
+    const { POST } = await loadRoute()
+    const messages = Array.from({ length: 51 }, () => ({ role: "user", content: "x" }))
+    expect((await POST(post({ messages }))).status).toBe(400)
+  })
+
+  it("400 over the total-character cap (8000)", async () => {
+    const { POST } = await loadRoute()
+    const messages = [{ role: "user", content: "x".repeat(8001) }]
+    expect((await POST(post({ messages }))).status).toBe(400)
+  })
+})
+
+describe("POST /api/chat — behavior", () => {
+  it("falls back to a canned reply (200, fallback:true) when no API key is set", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "")
+    const { POST } = await loadRoute()
+    const res = await POST(post(validBody))
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.fallback).toBe(true)
+    expect(typeof data.message).toBe("string")
+  })
+
+  it("rate-limits after 15 requests from the same IP (429 + retryAfter)", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "") // keep allowed requests on the no-network fallback path
+    const { POST } = await loadRoute()
+    const sameIp = { "x-forwarded-for": "203.0.113.7" }
+
+    let last: Response | undefined
+    for (let i = 0; i < 16; i++) {
+      last = await POST(post(validBody, sameIp))
+    }
+
+    expect(last!.status).toBe(429)
+    expect((await last!.json()).retryAfter).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/app/contact/whatsapp/route.test.ts
+++ b/app/contact/whatsapp/route.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+// A browser-like UA that does not trip the bot patterns, plus headers that
+// keep the abuse score at 0 so a valid challenge reaches the redirect.
+const GOOD_HEADERS = {
+  "user-agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+  referer: "https://davidtiz.com/",
+  "sec-fetch-site": "same-origin",
+}
+
+function url(query = "") {
+  return `https://davidtiz.com/contact/whatsapp${query}`
+}
+
+// Fresh module per test => fresh rate/replay state.
+async function loadRoute() {
+  vi.resetModules()
+  return import("@/app/contact/whatsapp/route")
+}
+
+afterEach(() => {
+  vi.resetModules()
+})
+
+describe("GET /contact/whatsapp — challenge guard", () => {
+  it("blocks a request with no challenge (403)", async () => {
+    const { GET } = await loadRoute()
+    const res = await GET(new NextRequest(url("?intent=portfolio")))
+    expect(res.status).toBe(403)
+  })
+
+  it("blocks when the query token and cookie token do not match (403)", async () => {
+    const { GET } = await loadRoute()
+    const cookieToken = `${"a".repeat(32)}.${Date.now()}`
+    const queryToken = `${"b".repeat(32)}.${Date.now()}`
+    const res = await GET(
+      new NextRequest(url(`?intent=portfolio&challenge=${queryToken}`), {
+        headers: { ...GOOD_HEADERS, cookie: `dzt-contact-challenge=${cookieToken}` },
+      }),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("redirects a valid challenge to wa.me (302), then rejects the replay (403)", async () => {
+    const { GET } = await loadRoute()
+    const token = `${"a1b2c3d4".repeat(4)}.${Date.now()}`
+    const request = () =>
+      new NextRequest(url(`?intent=portfolio&challenge=${token}`), {
+        headers: { ...GOOD_HEADERS, cookie: `dzt-contact-challenge=${token}` },
+      })
+
+    const ok = await GET(request())
+    expect(ok.status).toBe(302)
+    expect(ok.headers.get("location")).toContain("wa.me")
+
+    // Same single-use token again — now consumed.
+    const replay = await GET(request())
+    expect(replay.status).toBe(403)
+  })
+
+  it("blocks an expired challenge (403)", async () => {
+    const { GET } = await loadRoute()
+    const expired = `${"a".repeat(32)}.${Date.now() - 20 * 60_000}` // 20 min old
+    const res = await GET(
+      new NextRequest(url(`?intent=portfolio&challenge=${expired}`), {
+        headers: { ...GOOD_HEADERS, cookie: `dzt-contact-challenge=${expired}` },
+      }),
+    )
+    expect(res.status).toBe(403)
+  })
+})


### PR DESCRIPTION
Adds the follow-up coverage now that Vitest is in main, for the two logic-heavy routes. No production code changes — tests only.

## /api/chat (validation rejects before any model call)
- **400** on invalid JSON, missing/empty messages, invalid role or non-string content, >50 messages, >8000 total chars
- **200** canned fallback when no API key is set
- **429** after 15 requests from the same IP, with `retryAfter`

API key is stubbed empty so allowed requests stay on the no-network fallback path — **no real OpenRouter calls** in tests.

## /contact/whatsapp (challenge guard)
- **403** with no challenge, on cookie/query token mismatch, and on an expired token
- **302 → wa.me** for a valid challenge, then **403** on replay of the single-use token (full happy-path + replay exercised)

Each test re-imports the route (`vi.resetModules`) when fresh in-memory rate/replay state matters.

## Review follow-up
- Simplified duplicate validation assertions to reuse a single loaded route handler within the same test.
- Switched the chat test URL to `example.com` to keep tests environment-agnostic.

**Full suite: 26 passing** (4 files); lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)