### PR TITLE
feat: wire the local-business demos into the site (Q14)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,6 +51,7 @@ const workAreas = [
     image: "/visuals/local-business-system.svg",
     icon: Globe,
     tags: ["Next.js", "Forms", "Local SEO", "Handoff"],
+    cta: { label: "See live demos (pedidos, citas, servicios)", href: "/demo" },
   },
   {
     label: "Systems",
@@ -364,6 +365,12 @@ export default function HomePage() {
                       <li key={tag}>{tag}</li>
                     ))}
                   </ul>
+                  {"cta" in item && item.cta ? (
+                    <a className="dtz-card-link" href={item.cta.href}>
+                      {item.cta.label}
+                      <ArrowUpRight aria-hidden="true" />
+                    </a>
+                  ) : null}
                 </div>
               </motion.article>
             )

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,17 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  async rewrites() {
+    return [
+      // Clean URL for the static local-business demo hub in public/demo/.
+      // Sub-pages (pedidos/servicios/citas) keep their .html paths, which the
+      // hub's own nav already uses.
+      {
+        source: '/demo',
+        destination: '/demo/index.html',
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
The `public/demo` pages (hub + pedidos/servicios/citas) were unreachable: nothing on the site linked to them, and `/demo` 404'd because Next doesn't directory-index `public/`. The demos already point back at the site (`/contact/whatsapp?intent=localSite` in the hub footer) and `/pay` deep-links the pedidos demo — this closes the loop in the other direction.

## Changes
- **`next.config.mjs`**: rewrite `/demo` → `/demo/index.html` for a clean hub URL. Sub-pages keep their `.html` paths, which the hub's own nav already uses.
- **Homepage**: the *Local Business Sites* work card now links to `/demo` ("See live demos (pedidos, citas, servicios)"), rendered with the existing `dtz-card-link` style via an optional `cta` field on the work-area data.

## Verified (against `next start`, not just the build)
- `/demo` → 200 with the hub's title
- `/demo/{pedidos,servicios,citas}.html` → all 200
- Homepage HTML contains the `href="/demo"` CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)