### PR TITLE
feat: Meta coexistence token exchange behind a default-off flag (Q6)

### DIFF
--- a/app/api/meta/embedded-signup/callback/route.ts
+++ b/app/api/meta/embedded-signup/callback/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
   }
 
   const code = payload.loginResponse?.authResponse?.code
-  const codeReceived = typeof code === "string"
+  const codeReceived = typeof code === "string" && code.trim().length > 0
   const extracted = extractEmbeddedSignupIds(payload.sessionInfo)
 
   console.info("WhatsApp coexistence embedded signup callback recorded", {
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest) {
   } else if (!codeReceived) {
     tokenExchange = { attempted: false, reason: "No authorization code in the callback payload." }
   } else {
-    const result = await exchangeCoexistenceCode(code)
+    const result = await exchangeCoexistenceCode(code.trim())
 
     if (result.ok) {
       console.info("WhatsApp coexistence token exchange succeeded", {
@@ -125,7 +125,7 @@ export async function GET(request: NextRequest) {
   }
 
   console.info("WhatsApp coexistence embedded signup GET callback recorded", {
-    codeReceived: typeof code === "string" && code.length > 0,
+    codeReceived: typeof code === "string" && code.trim().length > 0,
   })
 
   return renderCallbackPage("Authorization code received", [

--- a/app/api/meta/embedded-signup/callback/route.ts
+++ b/app/api/meta/embedded-signup/callback/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
-import { verifyCoexistenceSignupState } from "@/lib/meta-embedded-signup"
+import {
+  exchangeCoexistenceCode,
+  isTokenExchangeEnabled,
+  redactIdentifier,
+  verifyCoexistenceSignupState,
+} from "@/lib/meta-embedded-signup"
 
 export const runtime = "nodejs"
 
@@ -24,7 +29,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid or expired state" }, { status: 401 })
   }
 
-  const codeReceived = typeof payload.loginResponse?.authResponse?.code === "string"
+  const code = payload.loginResponse?.authResponse?.code
+  const codeReceived = typeof code === "string"
   const extracted = extractEmbeddedSignupIds(payload.sessionInfo)
 
   console.info("WhatsApp coexistence embedded signup callback recorded", {
@@ -34,9 +40,59 @@ export async function POST(request: NextRequest) {
     wabaId: extracted.wabaId,
   })
 
+  // Server-side token exchange, gated by a default-off env flag. The signed
+  // state above already proves this request came from the admin-key-gated
+  // launcher, and the token is returned ONCE in this operator-facing response
+  // (the launcher renders it for the manual Doppler/Vercel env update). It is
+  // never logged and nothing in production is updated automatically.
+  let tokenExchange:
+    | { attempted: false; reason: string }
+    | { attempted: true; ok: false; error: string }
+    | {
+        attempted: true
+        ok: true
+        accessToken: string
+        tokenType: string | null
+        expiresIn: number | null
+        storeWith: string
+      }
+
+  if (!isTokenExchangeEnabled()) {
+    tokenExchange = {
+      attempted: false,
+      reason:
+        "Token exchange is disabled. Set META_EMBEDDED_SIGNUP_ALLOW_TOKEN_EXCHANGE=true to enable it for a deliberate launcher run.",
+    }
+  } else if (!codeReceived) {
+    tokenExchange = { attempted: false, reason: "No authorization code in the callback payload." }
+  } else {
+    const result = await exchangeCoexistenceCode(code)
+
+    if (result.ok) {
+      console.info("WhatsApp coexistence token exchange succeeded", {
+        expiresIn: result.expiresIn,
+        tokenPreview: redactIdentifier(result.accessToken),
+        tokenType: result.tokenType,
+      })
+      tokenExchange = {
+        attempted: true,
+        ok: true,
+        accessToken: result.accessToken,
+        tokenType: result.tokenType,
+        expiresIn: result.expiresIn,
+        storeWith:
+          "Shown once. Store manually: doppler secrets set WHATSAPP_ACCESS_TOKEN --project david-ortiz-portfolio. Do not commit it anywhere.",
+      }
+    } else {
+      console.error("WhatsApp coexistence token exchange failed", { error: result.error })
+      tokenExchange = { attempted: true, ok: false, error: result.error }
+    }
+  }
+
   return NextResponse.json({
     codeReceived,
     extracted,
+    tokenExchange,
     nextStep:
       "Do not update production IDs until 779 is confirmed to remain active in the WhatsApp Business app.",
     recorded: true,

--- a/app/api/meta/embedded-signup/status/route.ts
+++ b/app/api/meta/embedded-signup/status/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import {
   getCoexistencePublicConfig,
   getMissingCoexistenceConfig,
+  isTokenExchangeEnabled,
   isValidCoexistenceAdminKey,
   redactIdentifier,
 } from "@/lib/meta-embedded-signup"
@@ -20,6 +21,7 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({
     configured: missing.length === 0,
+    tokenExchangeEnabled: isTokenExchangeEnabled(),
     currentOfficialLane: {
       phoneNumberId: redactIdentifier(process.env.WHATSAPP_PHONE_NUMBER_ID),
       wabaId: redactIdentifier(process.env.WHATSAPP_BUSINESS_ACCOUNT_ID),

--- a/docs/WHATSAPP_COEXISTENCE_EMBEDDED_SIGNUP_SPEC.md
+++ b/docs/WHATSAPP_COEXISTENCE_EMBEDDED_SIGNUP_SPEC.md
@@ -123,7 +123,7 @@ Build a private operator-only signup launcher and callback handler.
 
 Do not expose `WHATSAPP_ACCESS_TOKEN` or `WHATSAPP_APP_SECRET` to client code.
 
-The first implementation is intentionally record-only. It does not exchange the returned OAuth code for a token. Add server-side token exchange only after the UI proves this is coexistence and `779` remains active in the WhatsApp Business app.
+The callback is record-only by default. Server-side token exchange is implemented but gated behind `META_EMBEDDED_SIGNUP_ALLOW_TOKEN_EXCHANGE=true` (default off). Enable the flag only for a deliberate launcher run, after the UI proves this is coexistence and `779` remains active in the WhatsApp Business app. On success the business token is returned once in the launcher's callback panel for the manual env update below; it is never logged and production is never updated automatically.
 
 ### Launcher route behavior
 

--- a/lib/meta-embedded-signup.test.ts
+++ b/lib/meta-embedded-signup.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   createCoexistenceSignupState,
+  exchangeCoexistenceCode,
+  isTokenExchangeEnabled,
   isValidCoexistenceAdminKey,
   redactIdentifier,
   verifyCoexistenceSignupState,
@@ -39,6 +41,81 @@ describe("isValidCoexistenceAdminKey", () => {
     expect(isValidCoexistenceAdminKey(ADMIN_KEY)).toBe(true)
     expect(isValidCoexistenceAdminKey("wrong-key")).toBe(false)
     expect(isValidCoexistenceAdminKey(null)).toBe(false)
+  })
+})
+
+describe("isTokenExchangeEnabled", () => {
+  it("is OFF by default and only enabled by the exact string 'true'", () => {
+    vi.stubEnv("META_EMBEDDED_SIGNUP_ALLOW_TOKEN_EXCHANGE", "")
+    expect(isTokenExchangeEnabled()).toBe(false)
+    vi.stubEnv("META_EMBEDDED_SIGNUP_ALLOW_TOKEN_EXCHANGE", "1")
+    expect(isTokenExchangeEnabled()).toBe(false)
+    vi.stubEnv("META_EMBEDDED_SIGNUP_ALLOW_TOKEN_EXCHANGE", "true")
+    expect(isTokenExchangeEnabled()).toBe(true)
+  })
+})
+
+describe("exchangeCoexistenceCode", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function stubCreds() {
+    vi.stubEnv("META_APP_ID", "123456")
+    vi.stubEnv("WHATSAPP_APP_SECRET", "app-secret")
+    vi.stubEnv("META_GRAPH_VERSION", "v25.0")
+    vi.stubEnv("META_EMBEDDED_SIGNUP_REDIRECT_URI", "https://davidtiz.com/api/meta/embedded-signup/callback")
+  }
+
+  it("fails fast without app credentials (no network call)", async () => {
+    vi.stubEnv("META_APP_ID", "")
+    vi.stubEnv("WHATSAPP_APP_SECRET", "")
+    const fetchSpy = vi.fn()
+    vi.stubGlobal("fetch", fetchSpy)
+
+    const result = await exchangeCoexistenceCode("code-123")
+    expect(result).toEqual({ ok: false, error: "missing-app-credentials" })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("exchanges a code against the Graph oauth endpoint and returns the token", async () => {
+    stubCreds()
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ access_token: "tok-abc", token_type: "bearer", expires_in: 5183944 }),
+        { status: 200 },
+      ),
+    )
+    vi.stubGlobal("fetch", fetchSpy)
+
+    const result = await exchangeCoexistenceCode("code-123")
+    expect(result).toEqual({ ok: true, accessToken: "tok-abc", tokenType: "bearer", expiresIn: 5183944 })
+
+    const calledUrl = String(fetchSpy.mock.calls[0][0])
+    expect(calledUrl).toContain("https://graph.facebook.com/v25.0/oauth/access_token")
+    expect(calledUrl).toContain("client_id=123456")
+    expect(calledUrl).toContain("code=code-123")
+  })
+
+  it("surfaces the Graph error message on a failed exchange", async () => {
+    stubCreds()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: "Invalid verification code" } }), { status: 400 }),
+      ),
+    )
+
+    const result = await exchangeCoexistenceCode("expired-code")
+    expect(result).toEqual({ ok: false, error: "Invalid verification code" })
+  })
+
+  it("reports a network failure without throwing", async () => {
+    stubCreds()
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")))
+
+    const result = await exchangeCoexistenceCode("code-123")
+    expect(result).toEqual({ ok: false, error: "network-error" })
   })
 })
 

--- a/lib/meta-embedded-signup.ts
+++ b/lib/meta-embedded-signup.ts
@@ -114,21 +114,21 @@ export async function exchangeCoexistenceCode(code: string): Promise<Coexistence
     return { ok: false, error: "missing-app-credentials" }
   }
 
-  const graphVersion = process.env.META_GRAPH_VERSION ?? DEFAULT_GRAPH_VERSION
-  const url = new URL(`https://graph.facebook.com/${graphVersion}/oauth/access_token`)
-  url.searchParams.set("client_id", appId)
-  url.searchParams.set("client_secret", appSecret)
-  url.searchParams.set("code", code)
-
-  const redirectUri = process.env.META_EMBEDDED_SIGNUP_REDIRECT_URI
-  if (redirectUri) {
-    url.searchParams.set("redirect_uri", redirectUri)
-  }
-
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), TOKEN_EXCHANGE_TIMEOUT_MS)
 
   try {
+    const graphVersion = process.env.META_GRAPH_VERSION ?? DEFAULT_GRAPH_VERSION
+    const url = new URL(`https://graph.facebook.com/${graphVersion}/oauth/access_token`)
+    url.searchParams.set("client_id", appId)
+    url.searchParams.set("client_secret", appSecret)
+    url.searchParams.set("code", code)
+
+    const redirectUri = process.env.META_EMBEDDED_SIGNUP_REDIRECT_URI
+    if (redirectUri) {
+      url.searchParams.set("redirect_uri", redirectUri)
+    }
+
     const response = await fetch(url, { signal: controller.signal })
     const data = (await response.json().catch(() => null)) as {
       access_token?: unknown

--- a/lib/meta-embedded-signup.ts
+++ b/lib/meta-embedded-signup.ts
@@ -91,6 +91,75 @@ export function verifyCoexistenceSignupState(state: string | null | undefined) {
   }
 }
 
+// Server-side OAuth code exchange for the coexistence flow. Default OFF:
+// the spec keeps the callback record-only until Meta actually offers this
+// app a coexistence path (currently blocked: "Embedded signup is only
+// available for BSPs or TPs"). Flip META_EMBEDDED_SIGNUP_ALLOW_TOKEN_EXCHANGE
+// to "true" only when running the launcher deliberately.
+export function isTokenExchangeEnabled() {
+  return process.env.META_EMBEDDED_SIGNUP_ALLOW_TOKEN_EXCHANGE === "true"
+}
+
+export type CoexistenceTokenExchange =
+  | { ok: true; accessToken: string; tokenType: string | null; expiresIn: number | null }
+  | { ok: false; error: string }
+
+const TOKEN_EXCHANGE_TIMEOUT_MS = 8000
+
+export async function exchangeCoexistenceCode(code: string): Promise<CoexistenceTokenExchange> {
+  const appId = process.env.META_APP_ID
+  const appSecret = process.env.WHATSAPP_APP_SECRET
+
+  if (!appId || !appSecret) {
+    return { ok: false, error: "missing-app-credentials" }
+  }
+
+  const graphVersion = process.env.META_GRAPH_VERSION ?? DEFAULT_GRAPH_VERSION
+  const url = new URL(`https://graph.facebook.com/${graphVersion}/oauth/access_token`)
+  url.searchParams.set("client_id", appId)
+  url.searchParams.set("client_secret", appSecret)
+  url.searchParams.set("code", code)
+
+  const redirectUri = process.env.META_EMBEDDED_SIGNUP_REDIRECT_URI
+  if (redirectUri) {
+    url.searchParams.set("redirect_uri", redirectUri)
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TOKEN_EXCHANGE_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    const data = (await response.json().catch(() => null)) as {
+      access_token?: unknown
+      token_type?: unknown
+      expires_in?: unknown
+      error?: { message?: string }
+    } | null
+
+    if (!response.ok || typeof data?.access_token !== "string") {
+      return {
+        ok: false,
+        error: data?.error?.message ?? `graph-status-${response.status}`,
+      }
+    }
+
+    return {
+      ok: true,
+      accessToken: data.access_token,
+      tokenType: typeof data.token_type === "string" ? data.token_type : null,
+      expiresIn: typeof data.expires_in === "number" ? data.expires_in : null,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error && error.name === "AbortError" ? "timeout" : "network-error",
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 export function redactIdentifier(value: string | null | undefined) {
   if (!value) {
     return null


### PR DESCRIPTION
Completes the missing server-side OAuth token exchange for the WhatsApp coexistence flow — **without changing the current safe posture**. Your ops doc records that Meta currently blocks Embedded Signup for this app (`Embedded signup is only available for BSPs or TPs`), so the exchange ships **default-off** and the callback stays record-only until you deliberately flip the flag for a launcher run.

## How it works
- **`exchangeCoexistenceCode(code)`** (lib): calls `graph.facebook.com/{version}/oauth/access_token` with `META_APP_ID` + `WHATSAPP_APP_SECRET` (+ `redirect_uri` when configured). 8s timeout, structured `ok/error` result, never throws.
- **Gate:** `META_EMBEDDED_SIGNUP_ALLOW_TOKEN_EXCHANGE=true` (exact string; `1`/`yes` do NOT enable it). Default **off** → behavior identical to today.
- **Callback POST:** when enabled and a non-blank code arrives, exchanges it server-side and returns the business token **once** in the operator-facing response — the admin-key-gated launcher renders that JSON, giving you the token for the manual `doppler secrets set WHATSAPP_ACCESS_TOKEN` step the spec prescribes. The HMAC-signed `state` (mintable only via the admin-gated launcher page) remains the operator proof.
- **Never** logged in full (only `redactIdentifier` preview + type/expiry), **never** auto-updates production IDs or env. GET callback stays record-only (a token must not transit a redirect URL).
- **Status route** now reports `tokenExchangeEnabled` so you can confirm the posture at a glance.
- Spec doc updated to describe the flag.

## Review follow-up
- Treats empty/whitespace authorization codes as absent so no unnecessary token exchange is attempted.
- Keeps the Graph URL construction inside the exchange guard/try path so setup failures are reported as structured `ok:false` results.

## Spec guardrails respected
- No migration/takeover action; nothing calls Meta until the flag is on **and** an operator completes the launcher.
- 'Do not update production env automatically' — unchanged.
- Hard-stop warnings in the launcher UI — unchanged.

## Tests
5 new (flag exact-match gating; exchange success / Graph error / network error; fail-fast without creds with **no network call**). 20 passing on this branch; lint + build clean.

## When Meta unblocks you
1. `doppler secrets set META_EMBEDDED_SIGNUP_ALLOW_TOKEN_EXCHANGE=true`
2. Run the launcher with the coexistence-only rule from the spec
3. Copy the token from the callback panel → `WHATSAPP_ACCESS_TOKEN`
4. Flip the flag back off

🤖 Generated with [Claude Code](https://claude.com/claude-code)