### PR TITLE
feat: optional shared persistence for abuse state (Q3)

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { contact } from "@/data/content"
+import { incrementWindow } from "@/lib/abuse-store"
 
 const SYSTEM_PROMPT = `You are an AI assistant for David Ortiz's personal site (davidtiz.com). This site is a personal notebook and portfolio, not a sales page.
 
@@ -27,11 +28,10 @@ interface ChatMessage {
 }
 
 // --- Rate limiting -----------------------------------------------------------
-// Per-IP sliding window. In-memory (per serverless instance, resets on cold
-// start) so it is best-effort, not a hard global guarantee — but it caps the
-// obvious abuse case (one client hammering the endpoint and billing the key).
+// Per-IP fixed window via lib/abuse-store: shared across instances when a
+// REST Redis (Vercel KV / Upstash) is configured, in-memory per instance
+// otherwise. Caps the abuse case of one client billing the OpenRouter key.
 const CHAT_RATE_LIMIT = { windowMs: 60_000, maxRequests: 15 }
-const chatRateBuckets = new Map<string, number[]>()
 
 function getClientIp(request: NextRequest) {
   return (
@@ -42,18 +42,11 @@ function getClientIp(request: NextRequest) {
   )
 }
 
-function rateLimit(ip: string) {
-  const now = Date.now()
-  const windowStart = now - CHAT_RATE_LIMIT.windowMs
-  const recent = (chatRateBuckets.get(ip) ?? []).filter((t) => t > windowStart)
-  if (recent.length >= CHAT_RATE_LIMIT.maxRequests) {
-    return {
-      allowed: false as const,
-      retryAfter: Math.ceil((recent[0] + CHAT_RATE_LIMIT.windowMs - now) / 1000),
-    }
+async function rateLimit(ip: string) {
+  const { count, retryAfterSeconds } = await incrementWindow(`chat:rate:${ip}`, CHAT_RATE_LIMIT.windowMs)
+  if (count > CHAT_RATE_LIMIT.maxRequests) {
+    return { allowed: false as const, retryAfter: retryAfterSeconds }
   }
-  recent.push(now)
-  chatRateBuckets.set(ip, recent)
   return { allowed: true as const }
 }
 
@@ -89,7 +82,7 @@ function isChatMessage(value: unknown): value is ChatMessage {
 export async function POST(request: NextRequest) {
   try {
     // Reject the cheap way first, before parsing or calling OpenRouter.
-    const limit = rateLimit(getClientIp(request))
+    const limit = await rateLimit(getClientIp(request))
     if (!limit.allowed) {
       return NextResponse.json(
         { error: "Too many requests", retryAfter: limit.retryAfter },

--- a/app/contact/whatsapp/route.ts
+++ b/app/contact/whatsapp/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { contact } from "@/data/content"
+import { hasTokenBeenUsed, incrementWindow, markTokenUsed } from "@/lib/abuse-store"
 
 const intentMessages = {
   portfolio: "Hola David, vi tu portafolio",
@@ -35,30 +36,9 @@ const contactChallengeCookieName = "dzt-contact-challenge"
 // actually targets the same cookie. A mismatch silently fails to clear it.
 const CONTACT_PATH = "/contact/whatsapp"
 const contactChallengeWindowMs = 10 * 60_000
-const rateBuckets = new Map<string, number[]>()
 const bucketWindowMs = 60_000
 const burstLimit = 6
-const usedChallenges = new Map<string, number>()
 const usedChallengeWindowMs = 2 * 60_000
-
-function cleanupUsedChallenges(now: number) {
-  for (const [token, expiresAt] of usedChallenges.entries()) {
-    if (expiresAt <= now) {
-      usedChallenges.delete(token)
-    }
-  }
-}
-
-function hasChallengeBeenUsed(token: string, now: number) {
-  cleanupUsedChallenges(now)
-
-  return usedChallenges.get(token) !== undefined
-}
-
-function trackUsedChallenge(token: string, now: number) {
-  usedChallenges.set(token, now + usedChallengeWindowMs)
-  cleanupUsedChallenges(now)
-}
 
 function isIntent(value: string | null): value is Intent {
   return Boolean(value && value in intentMessages)
@@ -134,7 +114,7 @@ function validateContactChallenge(request: NextRequest): ChallengeValidation {
   }
 }
 
-function scoreRequest(request: NextRequest, text: string): ScoredRequest {
+async function scoreRequest(request: NextRequest, text: string): Promise<ScoredRequest> {
   const userAgent = request.headers.get("user-agent") ?? ""
   const reasons: string[] = []
   let score = 0
@@ -169,8 +149,7 @@ function scoreRequest(request: NextRequest, text: string): ScoredRequest {
     }
   }
 
-  const now = Date.now()
-  if (hasChallengeBeenUsed(challenge.token!, now)) {
+  if (await hasTokenBeenUsed(`wa:${challenge.token!}`)) {
     return {
       blocked: true,
       reasons: ["contact-challenge-replay"],
@@ -198,12 +177,9 @@ function scoreRequest(request: NextRequest, text: string): ScoredRequest {
   }
 
   const ip = getClientIp(request)
-  const events = rateBuckets.get(ip) ?? []
-  const activeEvents = events.filter((ts) => ts > now - bucketWindowMs)
-  activeEvents.push(now)
-  rateBuckets.set(ip, activeEvents)
+  const { count } = await incrementWindow(`wa:burst:${ip}`, bucketWindowMs)
 
-  if (activeEvents.length > burstLimit) {
+  if (count > burstLimit) {
     score += 3
     reasons.push("ip-burst-limit")
   }
@@ -247,13 +223,13 @@ function markChallengeCookieConsumed(response: NextResponse, request: NextReques
   )
 }
 
-export function GET(request: NextRequest) {
+export async function GET(request: NextRequest) {
   const intent = request.nextUrl.searchParams.get("intent")
   const safeIntent: Intent = isIntent(intent) ? intent : "portfolio"
   const customText = request.nextUrl.searchParams.get("text")?.trim()
   const baseMessage = customText && customText.length > 0 ? customText : intentMessages[safeIntent]
   const message = stripPotentialSpamText(baseMessage)
-  const risk = scoreRequest(request, message)
+  const risk = await scoreRequest(request, message)
 
   if (risk.blocked) {
     const reasonPayload = risk.reasons.length ? risk.reasons.join(",") : "no-reason"
@@ -269,7 +245,7 @@ export function GET(request: NextRequest) {
   const response = NextResponse.redirect(target, 302)
   const challenge = parseChallengeValue(request.nextUrl.searchParams.get("challenge"))
   if (challenge?.token) {
-    trackUsedChallenge(challenge.token, Date.now())
+    await markTokenUsed(`wa:${challenge.token}`, usedChallengeWindowMs)
   }
 
   markChallengeCookieConsumed(response, request)

--- a/lib/abuse-store.test.ts
+++ b/lib/abuse-store.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Fresh module per test so the in-memory fallback state never leaks between tests.
+async function loadStore() {
+  vi.resetModules()
+  return import("@/lib/abuse-store")
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+  vi.resetModules()
+})
+
+describe("abuse-store (in-memory fallback, no Redis configured)", () => {
+  beforeEach(() => {
+    vi.stubEnv("KV_REST_API_URL", "")
+    vi.stubEnv("KV_REST_API_TOKEN", "")
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "")
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "")
+  })
+
+  it("reports the persistent store as not configured", async () => {
+    const store = await loadStore()
+    expect(store.isPersistentAbuseStoreConfigured()).toBe(false)
+  })
+
+  it("counts events within a window and resets after it elapses", async () => {
+    vi.useFakeTimers()
+    const store = await loadStore()
+
+    expect((await store.incrementWindow("k", 60_000)).count).toBe(1)
+    expect((await store.incrementWindow("k", 60_000)).count).toBe(2)
+    expect((await store.incrementWindow("other", 60_000)).count).toBe(1)
+
+    vi.advanceTimersByTime(61_000)
+    expect((await store.incrementWindow("k", 60_000)).count).toBe(1)
+  })
+
+  it("tracks single-use tokens until their ttl expires", async () => {
+    vi.useFakeTimers()
+    const store = await loadStore()
+
+    expect(await store.hasTokenBeenUsed("tok")).toBe(false)
+    await store.markTokenUsed("tok", 2_000)
+    expect(await store.hasTokenBeenUsed("tok")).toBe(true)
+
+    vi.advanceTimersByTime(2_500)
+    expect(await store.hasTokenBeenUsed("tok")).toBe(false)
+  })
+})
+
+describe("abuse-store (REST Redis configured)", () => {
+  beforeEach(() => {
+    vi.stubEnv("KV_REST_API_URL", "https://fake-kv.example.com")
+    vi.stubEnv("KV_REST_API_TOKEN", "fake-token")
+  })
+
+  function pipelineResponse(results: unknown[]) {
+    return new Response(JSON.stringify(results.map((result) => ({ result }))), { status: 200 })
+  }
+
+  it("uses INCR/PEXPIRE/PTTL for windows and maps the results", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(pipelineResponse([7, 1, 30_000]))
+    vi.stubGlobal("fetch", fetchSpy)
+    const store = await loadStore()
+
+    const result = await store.incrementWindow("chat:rate:1.2.3.4", 60_000)
+    expect(result).toEqual({ count: 7, retryAfterSeconds: 30 })
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(String(url)).toBe("https://fake-kv.example.com/pipeline")
+    expect(init.headers.Authorization).toBe("Bearer fake-token")
+    const commands = JSON.parse(init.body)
+    expect(commands[0]).toEqual(["INCR", "dtz:abuse:chat:rate:1.2.3.4"])
+    expect(commands[1]).toEqual(["PEXPIRE", "dtz:abuse:chat:rate:1.2.3.4", 60_000, "NX"])
+    expect(commands[2]).toEqual(["PTTL", "dtz:abuse:chat:rate:1.2.3.4"])
+  })
+
+  it("answers replay checks via EXISTS and marks tokens via SET PX", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(pipelineResponse([0]))
+      .mockResolvedValueOnce(pipelineResponse(["OK"]))
+      .mockResolvedValueOnce(pipelineResponse([1]))
+    vi.stubGlobal("fetch", fetchSpy)
+    const store = await loadStore()
+
+    expect(await store.hasTokenBeenUsed("tok")).toBe(false)
+    await store.markTokenUsed("tok", 120_000)
+    expect(await store.hasTokenBeenUsed("tok")).toBe(true)
+
+    const setCommands = JSON.parse(fetchSpy.mock.calls[1][1].body)
+    expect(setCommands[0]).toEqual(["SET", "dtz:abuse:used:tok", "1", "PX", 120_000])
+  })
+
+  it("fails open to the in-memory fallback when Redis is unreachable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")))
+    const store = await loadStore()
+
+    // Still enforces counting locally instead of throwing or always-allowing.
+    expect((await store.incrementWindow("k", 60_000)).count).toBe(1)
+    expect((await store.incrementWindow("k", 60_000)).count).toBe(2)
+
+    await store.markTokenUsed("tok", 60_000)
+    expect(await store.hasTokenBeenUsed("tok")).toBe(true)
+  })
+})

--- a/lib/abuse-store.ts
+++ b/lib/abuse-store.ts
@@ -41,7 +41,10 @@ async function redisPipeline(config: RedisConfig, commands: RedisCommand[]): Pro
       signal: controller.signal,
     })
 
-    if (!response.ok) return null
+    if (!response.ok) {
+      await response.body?.cancel()
+      return null
+    }
 
     const data = (await response.json()) as { result?: unknown; error?: string }[]
     if (!Array.isArray(data) || data.some((entry) => entry.error)) return null
@@ -59,8 +62,15 @@ async function redisPipeline(config: RedisConfig, commands: RedisCommand[]): Pro
 type MemoryWindow = { count: number; resetAt: number }
 const memoryWindows = new Map<string, MemoryWindow>()
 
+function memoryCleanupWindows(now: number) {
+  for (const [key, window] of memoryWindows.entries()) {
+    if (window.resetAt <= now) memoryWindows.delete(key)
+  }
+}
+
 function memoryIncrementWindow(key: string, windowMs: number) {
   const now = Date.now()
+  memoryCleanupWindows(now)
   const existing = memoryWindows.get(key)
 
   if (!existing || existing.resetAt <= now) {

--- a/lib/abuse-store.ts
+++ b/lib/abuse-store.ts
@@ -1,0 +1,137 @@
+import "server-only"
+
+// Shared store for abuse-control state (rate windows, single-use challenge
+// tokens). On serverless, module-level Maps are per-instance and reset on
+// cold start, so enforcement is best-effort. When an Upstash-compatible REST
+// Redis is configured (Vercel KV / Marketplace Redis / Upstash), state is
+// shared across instances; otherwise everything falls back to the in-memory
+// Maps with identical semantics. Redis errors fail OPEN to in-memory: this
+// state guards abuse, so availability of the real feature wins over strict
+// enforcement.
+
+const REDIS_TIMEOUT_MS = 800
+const KEY_PREFIX = "dtz:abuse:"
+
+type RedisConfig = { url: string; token: string }
+
+function getRedisConfig(): RedisConfig | null {
+  const url = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL
+  const token = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN
+  return url && token ? { url: url.replace(/\/$/, ""), token } : null
+}
+
+export function isPersistentAbuseStoreConfigured() {
+  return getRedisConfig() !== null
+}
+
+type RedisCommand = (string | number)[]
+
+async function redisPipeline(config: RedisConfig, commands: RedisCommand[]): Promise<unknown[] | null> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REDIS_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(`${config.url}/pipeline`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(commands),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) return null
+
+    const data = (await response.json()) as { result?: unknown; error?: string }[]
+    if (!Array.isArray(data) || data.some((entry) => entry.error)) return null
+
+    return data.map((entry) => entry.result)
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+// --- Fixed-window rate counting ----------------------------------------------
+
+type MemoryWindow = { count: number; resetAt: number }
+const memoryWindows = new Map<string, MemoryWindow>()
+
+function memoryIncrementWindow(key: string, windowMs: number) {
+  const now = Date.now()
+  const existing = memoryWindows.get(key)
+
+  if (!existing || existing.resetAt <= now) {
+    memoryWindows.set(key, { count: 1, resetAt: now + windowMs })
+    return { count: 1, retryAfterSeconds: Math.ceil(windowMs / 1000) }
+  }
+
+  existing.count += 1
+  return { count: existing.count, retryAfterSeconds: Math.ceil((existing.resetAt - now) / 1000) }
+}
+
+/**
+ * Count one event in a fixed window. Returns the event count within the
+ * current window (1 = first event) and seconds until the window resets.
+ */
+export async function incrementWindow(
+  key: string,
+  windowMs: number,
+): Promise<{ count: number; retryAfterSeconds: number }> {
+  const config = getRedisConfig()
+  if (config) {
+    const fullKey = `${KEY_PREFIX}${key}`
+    const results = await redisPipeline(config, [
+      ["INCR", fullKey],
+      ["PEXPIRE", fullKey, windowMs, "NX"],
+      ["PTTL", fullKey],
+    ])
+
+    if (results && typeof results[0] === "number") {
+      const ttl = typeof results[2] === "number" && results[2] > 0 ? results[2] : windowMs
+      return { count: results[0], retryAfterSeconds: Math.ceil(ttl / 1000) }
+    }
+  }
+
+  return memoryIncrementWindow(key, windowMs)
+}
+
+// --- Single-use token tracking -------------------------------------------------
+
+const memoryUsedTokens = new Map<string, number>()
+
+function memoryCleanupUsedTokens(now: number) {
+  for (const [token, expiresAt] of memoryUsedTokens.entries()) {
+    if (expiresAt <= now) memoryUsedTokens.delete(token)
+  }
+}
+
+/** True if the token was already consumed (replay). Read-only. */
+export async function hasTokenBeenUsed(key: string): Promise<boolean> {
+  const config = getRedisConfig()
+  if (config) {
+    const results = await redisPipeline(config, [["EXISTS", `${KEY_PREFIX}used:${key}`]])
+    if (results && typeof results[0] === "number") {
+      return results[0] === 1
+    }
+  }
+
+  const now = Date.now()
+  memoryCleanupUsedTokens(now)
+  return memoryUsedTokens.has(key)
+}
+
+/** Mark a token consumed for ttlMs (call only after the action succeeds). */
+export async function markTokenUsed(key: string, ttlMs: number): Promise<void> {
+  const config = getRedisConfig()
+  if (config) {
+    const results = await redisPipeline(config, [["SET", `${KEY_PREFIX}used:${key}`, "1", "PX", ttlMs]])
+    if (results) return
+  }
+
+  const now = Date.now()
+  memoryUsedTokens.set(key, now + ttlMs)
+  memoryCleanupUsedTokens(now)
+}


### PR DESCRIPTION
Implements the abuse-state persistence decision (Q3). The WhatsApp redirect's replay/burst tracking and the chat rate limiter lived in module-level Maps — per serverless instance, reset on cold start — so replay protection and rate limits were best-effort only.

## Design: opt-in Redis, identical fallback, fail-open
New `lib/abuse-store.ts`:
- **When a REST Redis is configured** (`KV_REST_API_URL`/`KV_REST_API_TOKEN` or `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` — Vercel KV, Vercel Marketplace Redis, or Upstash all expose these), state is shared across all instances via the REST pipeline API. Plain `fetch`, 800ms timeout, **zero new npm dependencies**.
- **When not configured** (today's state): in-memory Maps with identical semantics — behavior is exactly what's deployed now.
- **On Redis errors: fails OPEN to in-memory.** Abuse control should never take down the contact path or chat.

API: `incrementWindow` (fixed-window count + retry-after), `hasTokenBeenUsed`/`markTokenUsed` (single-use challenge tokens).

## Wired into
- **/contact/whatsapp** — replay check + per-IP burst counting now go through the store. The challenge token is still only burned **after** a successful redirect, exactly as before.
- **/api/chat** — per-IP rate limit (15/min unchanged; sliding window → fixed window, same rejection threshold).

## Review follow-up
- Added cleanup for expired in-memory rate windows so warm instances do not accumulate stale unique-IP/key entries.
- Cancels non-OK Redis response bodies before fail-open fallback.

## To activate shared state
Provision a Redis (Vercel Marketplace → Upstash is the one-click path) and the env vars appear automatically; no code change. Until then this PR is a no-op behaviorally.

## Tests
6 new: in-memory counting + window reset + token TTL expiry (fake timers), Redis pipeline command shapes (`INCR/PEXPIRE/PTTL`, `EXISTS`, `SET PX`), and fail-open when Redis is unreachable. 21 passing; lint + build clean.

## Merge note
Compatible with open PRs #62/#64 (different hunks of the same routes; the #64 behavior tests pass unchanged against the in-memory fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)