### PR TITLE
fix: unbreak main CI — case-insensitive SameSite cookie assertion

### DIFF
--- a/app/contact/whatsapp/challenge/route.test.ts
+++ b/app/contact/whatsapp/challenge/route.test.ts
@@ -16,7 +16,9 @@ describe("GET /contact/whatsapp/challenge", () => {
     expect(setCookie).toContain(`dzt-contact-challenge=${body.token}`)
     expect(setCookie).toContain("HttpOnly")
     expect(setCookie).toContain("Path=/contact/whatsapp")
-    expect(setCookie).toContain("SameSite=Lax")
+    // Cookie attribute values are case-insensitive; Next's cookie serializer
+    // emits `SameSite=lax` while a raw header would say `SameSite=Lax`.
+    expect(setCookie.toLowerCase()).toContain("samesite=lax")
   })
 
   it("marks the token response no-store so tokens are never cached", () => {

--- a/app/contact/whatsapp/challenge/route.test.ts
+++ b/app/contact/whatsapp/challenge/route.test.ts
@@ -18,7 +18,7 @@ describe("GET /contact/whatsapp/challenge", () => {
     expect(setCookie).toContain("Path=/contact/whatsapp")
     // Cookie attribute values are case-insensitive; Next's cookie serializer
     // emits `SameSite=lax` while a raw header would say `SameSite=Lax`.
-    expect(setCookie.toLowerCase()).toContain("samesite=lax")
+    expect(setCookie).toMatch(/samesite=lax/i)
   })
 
   it("marks the token response no-store so tokens are never cached", () => {


### PR DESCRIPTION
**Merge this first — main CI has been red since #62 merged** (and #66's branch CI failure is this same test, inherited from the base).

## What broke
The #62 review patch switched `/contact/whatsapp/challenge` from a raw `Set-Cookie` header string (emits `SameSite=Lax`) to Next's `response.cookies.set()`, whose serializer emits `SameSite=lax` (lowercase). The test still asserted `"SameSite=Lax"` → the only failing test on main:

```
AssertionError: expected '…Secure; HttpOnly; SameSite=lax' to contain 'SameSite=Lax'
```

## Fix
Cookie attribute values are case-insensitive per spec, so the assertion now uses a case-insensitive regex. Test-only, one assertion. 19/19 passing locally against main.

## Review follow-up
- Switched from lowercasing the full cookie header to `toMatch(/samesite=lax/i)` per AI review.

After this lands, re-running CI on #66 (or just merging the queue) should go green — the #66 patches themselves are sound; its red check is inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)