### PR TITLE
feat: unify the whole site on the dtz design language + close structural holes

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -24,6 +24,7 @@ import {
 import { personalSitePublicLabel } from "@/lib/site-config"
 import { whatsappHref } from "@/data/content"
 import { ProtectedWhatsAppLink } from "@/components/contact/protected-whatsapp-link"
+import { ThemeShell } from "@/components/theme-shell"
 
 export const metadata: Metadata = {
   title: "Contact | David Ortiz",
@@ -32,33 +33,93 @@ export const metadata: Metadata = {
 }
 
 function iconFor(link: ContactLink) {
+  const props = { className: "h-4 w-4", "aria-hidden": true } as const
   switch (link.id) {
     case "email":
-      return Mail
+      return <Mail {...props} />
     case "calendly":
-      return CalendarDays
+      return <CalendarDays {...props} />
     case "upwork":
     case "fiverr":
     case "high-encode":
     case "business-inbox":
-      return BriefcaseBusiness
+      return <BriefcaseBusiness {...props} />
     case "facebook":
-      return FacebookIcon
+      return <FacebookIcon {...props} />
     case "instagram":
-      return InstagramIcon
+      return <InstagramIcon {...props} />
     case "linkedin":
-      return LinkedinIcon
+      return <LinkedinIcon {...props} />
     case "whatsapp":
-      return MessageCircle
+      return <MessageCircle {...props} />
     case "github":
-      return GithubIcon
+      return <GithubIcon {...props} />
     default:
-      return ExternalLink
+      return <ExternalLink {...props} />
   }
 }
 
 function isExternal(href: string) {
   return href.startsWith("http")
+}
+
+const tileClass =
+  "group flex items-start gap-3 rounded-2xl border px-4 py-4 transition-colors"
+const tileStyle = {
+  borderColor: "var(--dtz-border)",
+  background: "var(--dtz-panel-2)",
+} as const
+const iconChipStyle = {
+  background: "var(--dtz-accent-soft)",
+  color: "var(--dtz-accent)",
+} as const
+
+function ContactTile({ link }: { link: ContactLink }) {
+  const body = (
+    <>
+      <span
+        className="mt-0.5 flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl"
+        style={iconChipStyle}
+      >
+        {iconFor(link)}
+      </span>
+      <span className="min-w-0">
+        <span className="flex items-center gap-2 text-sm font-semibold" style={{ color: "var(--dtz-fg)" }}>
+          {link.label}
+          <ArrowRight
+            className="h-4 w-4 transition-transform group-hover:translate-x-0.5"
+            style={{ color: "var(--dtz-subtle)" }}
+            aria-hidden="true"
+          />
+        </span>
+        <span className="mt-1 block text-xs leading-relaxed" style={{ color: "var(--dtz-muted)" }}>
+          {link.description}
+        </span>
+      </span>
+    </>
+  )
+
+  return link.id === "whatsapp" ? (
+    <ProtectedWhatsAppLink
+      href={link.href}
+      target={isExternal(link.href) ? "_blank" : undefined}
+      rel={isExternal(link.href) ? "noopener noreferrer" : undefined}
+      className={tileClass}
+      style={tileStyle}
+    >
+      {body}
+    </ProtectedWhatsAppLink>
+  ) : (
+    <a
+      href={link.href}
+      target={isExternal(link.href) ? "_blank" : undefined}
+      rel={isExternal(link.href) ? "noopener noreferrer" : undefined}
+      className={tileClass}
+      style={tileStyle}
+    >
+      {body}
+    </a>
+  )
 }
 
 export default function ContactPage() {
@@ -82,100 +143,84 @@ export default function ContactPage() {
   ]
 
   return (
-    <main className="min-h-screen bg-[#060a14] px-6 py-20 text-white">
-      <div className="mx-auto max-w-6xl">
-        <div className="mb-12 max-w-3xl">
-          <p className="text-xs uppercase tracking-[0.24em] text-[#2dd4bf]">Contact</p>
-          <h1 className="mt-4 text-4xl font-bold md:text-5xl">A direct path to David, without making people guess</h1>
-          <p className="mt-5 text-lg leading-relaxed text-white/55">
-            {personalSitePublicLabel} stays personal, experimental, and reflective. This page is the shareable contact hub:
-            the fastest confirmed ways to email, book time, start a freelance conversation, or move into a scoped business discussion.
-          </p>
-          <div className="mt-6 flex flex-wrap gap-3">
-            <span className="rounded-full border border-[#2dd4bf]/20 bg-[#2dd4bf]/10 px-4 py-2 text-xs font-medium uppercase tracking-[0.18em] text-[#9ae6db]">
-              English + Español welcome
-            </span>
-            <Link
-              href="/"
-              className="rounded-full border border-white/10 px-4 py-2 text-sm text-white/60 transition-colors hover:text-white"
+    <ThemeShell>
+      <main className="min-h-screen px-6 py-20">
+        <div className="mx-auto max-w-6xl">
+          <div className="mb-12 max-w-3xl">
+            <p className="dtz-section-label">Contact</p>
+            <h1 className="mt-4 text-4xl font-bold md:text-5xl">
+              A direct path to David, without making people guess
+            </h1>
+            <p className="mt-5 text-lg leading-relaxed" style={{ color: "var(--dtz-muted)" }}>
+              {personalSitePublicLabel} stays personal, experimental, and reflective. This page is the shareable contact hub:
+              the fastest confirmed ways to email, book time, start a freelance conversation, or move into a scoped business discussion.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <span
+                className="rounded-full border px-4 py-2 text-xs font-medium uppercase tracking-[0.18em]"
+                style={{
+                  borderColor: "var(--dtz-border)",
+                  background: "var(--dtz-accent-soft)",
+                  color: "var(--dtz-accent)",
+                }}
+              >
+                English + Español welcome
+              </span>
+              <Link
+                href="/"
+                className="rounded-full border px-4 py-2 text-sm transition-colors"
+                style={{ borderColor: "var(--dtz-border)", color: "var(--dtz-muted)" }}
+              >
+                Back to home
+              </Link>
+            </div>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-3">
+            {groups.map(group => (
+              <section
+                key={group.heading}
+                className="rounded-3xl border p-6"
+                style={{ borderColor: "var(--dtz-border)", background: "var(--dtz-panel)" }}
+              >
+                <p className="dtz-section-label">{group.heading}</p>
+                <p className="mt-3 text-sm leading-relaxed" style={{ color: "var(--dtz-muted)" }}>
+                  {group.intro}
+                </p>
+
+                <div className="mt-6 space-y-3">
+                  {group.links.map(link => (
+                    <ContactTile key={link.id} link={link} />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+
+          <div
+            className="mt-8 rounded-3xl border px-6 py-5"
+            style={{ borderColor: "var(--dtz-border)", background: "var(--dtz-panel)" }}
+          >
+            <p className="text-sm font-semibold" style={{ color: "var(--dtz-fg)" }}>
+              Prefer a structured intake?
+            </p>
+            <p className="mt-2 text-sm" style={{ color: "var(--dtz-muted)" }}>
+              I keep the first message short on purpose. If this is a real project, send scope and timeline so I can
+              respond quickly with realistic next steps.
+            </p>
+            <ProtectedWhatsAppLink
+              href={whatsappHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-flex items-center gap-2 rounded-2xl px-5 py-3 font-semibold transition-transform hover:scale-[1.01]"
+              style={{ background: "var(--dtz-accent)", color: "var(--dtz-on-accent)" }}
             >
-              Back to home
-            </Link>
+              Start a project on WhatsApp
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </ProtectedWhatsAppLink>
           </div>
         </div>
-
-        <div className="grid gap-6 lg:grid-cols-3">
-          {groups.map(group => (
-            <section key={group.heading} className="rounded-3xl border border-white/8 bg-white/[0.03] p-6">
-              <p className="text-xs uppercase tracking-[0.22em] text-[#22d3ee]">{group.heading}</p>
-              <p className="mt-3 text-sm leading-relaxed text-white/50">{group.intro}</p>
-
-              <div className="mt-6 space-y-3">
-                {group.links.map(link => {
-                  const Icon = iconFor(link)
-
-                  return link.id === "whatsapp" ? (
-                    <ProtectedWhatsAppLink
-                      key={link.id}
-                      href={link.href}
-                      target={isExternal(link.href) ? "_blank" : undefined}
-                      rel={isExternal(link.href) ? "noopener noreferrer" : undefined}
-                      className="group flex items-start gap-3 rounded-2xl border border-white/8 bg-[#0b1424]/75 px-4 py-4 transition-colors hover:border-white/20 hover:bg-[#0f1a2f]"
-                    >
-                      <span className="mt-0.5 flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-[#ff6b6b] to-[#ff8e8e] text-white shadow-lg shadow-[#ff6b6b]/10">
-                        <Icon className="h-4 w-4" />
-                      </span>
-                      <span className="min-w-0">
-                        <span className="flex items-center gap-2 text-sm font-semibold text-white">
-                          {link.label}
-                          <ArrowRight className="h-4 w-4 text-white/30 transition-transform group-hover:translate-x-0.5" />
-                        </span>
-                        <span className="mt-1 block text-xs leading-relaxed text-white/50">{link.description}</span>
-                      </span>
-                    </ProtectedWhatsAppLink>
-                  ) : (
-                    <a
-                      key={link.id}
-                      href={link.href}
-                      target={isExternal(link.href) ? "_blank" : undefined}
-                      rel={isExternal(link.href) ? "noopener noreferrer" : undefined}
-                      className="group flex items-start gap-3 rounded-2xl border border-white/8 bg-[#0b1424]/75 px-4 py-4 transition-colors hover:border-white/20 hover:bg-[#0f1a2f]"
-                    >
-                      <span className="mt-0.5 flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-[#ff6b6b] to-[#ff8e8e] text-white shadow-lg shadow-[#ff6b6b]/10">
-                        <Icon className="h-4 w-4" />
-                      </span>
-                      <span className="min-w-0">
-                        <span className="flex items-center gap-2 text-sm font-semibold text-white">
-                          {link.label}
-                          <ArrowRight className="h-4 w-4 text-white/30 transition-transform group-hover:translate-x-0.5" />
-                        </span>
-                        <span className="mt-1 block text-xs leading-relaxed text-white/50">{link.description}</span>
-                      </span>
-                    </a>
-                  )
-                })}
-              </div>
-            </section>
-          ))}
-        </div>
-
-        <div className="mt-8 rounded-3xl border border-white/8 bg-[#08101e]/75 px-6 py-5">
-          <p className="text-sm font-semibold text-white">Prefer a structured intake?</p>
-          <p className="mt-2 text-sm text-white/45">
-            I keep the first message short on purpose. If this is a real project, send scope and timeline so I can
-            respond quickly with realistic next steps.
-          </p>
-          <ProtectedWhatsAppLink
-            href={whatsappHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-4 inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[#2dd4bf] to-[#22d3ee] px-5 py-3 font-semibold text-[#060a14] transition-transform hover:scale-[1.01]"
-          >
-            Start a project on WhatsApp
-            <ArrowRight className="h-4 w-4" />
-          </ProtectedWhatsAppLink>
-        </div>
-      </div>
-    </main>
+      </main>
+    </ThemeShell>
   )
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react"
 import Link from "next/link"
+import { ThemeShell } from "@/components/theme-shell"
 
 export default function Error({
   error,
@@ -16,60 +17,76 @@ export default function Error({
   }, [error])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#060a14] px-4">
-      <div className="glass rounded-2xl p-8 max-w-md text-center">
-        <div className="w-16 h-16 mx-auto mb-6 rounded-full bg-[#ff6b6b]/20 flex items-center justify-center">
-          <svg
-            className="w-8 h-8 text-[#ff6b6b]"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
+    <ThemeShell>
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div
+          className="rounded-3xl border p-8 max-w-md text-center"
+          style={{
+            borderColor: "var(--dtz-border)",
+            background: "var(--dtz-panel)",
+            boxShadow: "var(--dtz-shadow)",
+          }}
+        >
+          <div
+            className="w-16 h-16 mx-auto mb-6 rounded-full flex items-center justify-center"
+            style={{ background: "var(--dtz-accent-soft)" }}
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-            />
-          </svg>
+            <svg
+              className="w-8 h-8"
+              style={{ color: "var(--dtz-accent-2)" }}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          </div>
+
+          <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
+
+          <p className="mb-6" style={{ color: "var(--dtz-muted)" }}>
+            We encountered an unexpected error. Don&apos;t worry, your data is safe.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <button
+              onClick={reset}
+              className="px-6 py-3 font-semibold rounded-xl transition-opacity hover:opacity-90"
+              style={{ background: "var(--dtz-accent)", color: "var(--dtz-on-accent)" }}
+            >
+              Try again
+            </button>
+
+            <Link
+              href="/"
+              className="px-6 py-3 border font-semibold rounded-xl transition-colors"
+              style={{ borderColor: "var(--dtz-border)", color: "var(--dtz-muted)" }}
+            >
+              Go home
+            </Link>
+          </div>
+
+          {process.env.NODE_ENV === "development" && error.message && (
+            <details className="mt-6 text-left">
+              <summary className="text-sm cursor-pointer" style={{ color: "var(--dtz-muted)" }}>
+                Error details (dev only)
+              </summary>
+              <pre
+                className="mt-2 p-3 rounded-lg text-xs overflow-auto max-h-32"
+                style={{ background: "var(--dtz-panel-2)", color: "var(--dtz-accent-2)" }}
+              >
+                {error.message}
+              </pre>
+            </details>
+          )}
         </div>
-
-        <h1 className="text-2xl font-bold text-white mb-2">
-          Something went wrong
-        </h1>
-
-        <p className="text-white/60 mb-6">
-          We encountered an unexpected error. Don&apos;t worry, your data is safe.
-        </p>
-
-        <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <button
-            onClick={reset}
-            className="px-6 py-3 bg-gradient-to-r from-[#2dd4bf] to-[#22d3ee] text-[#060a14] font-semibold rounded-xl hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-[#2dd4bf] focus:ring-offset-2 focus:ring-offset-[#060a14]"
-          >
-            Try again
-          </button>
-
-          <Link
-            href="/"
-            className="px-6 py-3 border border-white/20 text-white font-semibold rounded-xl hover:bg-white/5 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-[#060a14]"
-          >
-            Go home
-          </Link>
-        </div>
-
-        {process.env.NODE_ENV === "development" && error.message && (
-          <details className="mt-6 text-left">
-            <summary className="text-white/75 text-sm cursor-pointer hover:text-white/60">
-              Error details (dev only)
-            </summary>
-            <pre className="mt-2 p-3 bg-black/30 rounded-lg text-xs text-[#ff6b6b] overflow-auto max-h-32">
-              {error.message}
-            </pre>
-          </details>
-        )}
       </div>
-    </div>
+    </ThemeShell>
   )
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -16,7 +16,7 @@ export default function GlobalError({
 
   return (
     <html lang="en">
-      <body style={{ margin: 0, backgroundColor: "#060a14" }}>
+      <body style={{ margin: 0, backgroundColor: "#ddebe6" }}>
         <div
           style={{
             minHeight: "100vh",
@@ -29,13 +29,13 @@ export default function GlobalError({
         >
           <div
             style={{
-              background: "rgba(255, 255, 255, 0.05)",
+              background: "#f4fbf7",
               backdropFilter: "blur(20px)",
               borderRadius: "1rem",
               padding: "2rem",
               maxWidth: "28rem",
               textAlign: "center",
-              border: "1px solid rgba(255, 255, 255, 0.1)",
+              border: "1px solid #6f8f88",
             }}
           >
             <div
@@ -44,7 +44,7 @@ export default function GlobalError({
                 height: "4rem",
                 margin: "0 auto 1.5rem",
                 borderRadius: "50%",
-                background: "rgba(255, 107, 107, 0.2)",
+                background: "#cceee6",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
@@ -54,7 +54,7 @@ export default function GlobalError({
                 width="32"
                 height="32"
                 fill="none"
-                stroke="#ff6b6b"
+                stroke="#9b352d"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
               >
@@ -71,7 +71,7 @@ export default function GlobalError({
               style={{
                 fontSize: "1.5rem",
                 fontWeight: "bold",
-                color: "#ffffff",
+                color: "#061513",
                 marginBottom: "0.5rem",
               }}
             >
@@ -80,7 +80,7 @@ export default function GlobalError({
 
             <p
               style={{
-                color: "rgba(255, 255, 255, 0.6)",
+                color: "#243c38",
                 marginBottom: "1.5rem",
                 lineHeight: 1.5,
               }}
@@ -93,8 +93,8 @@ export default function GlobalError({
                 onClick={reset}
                 style={{
                   padding: "0.75rem 1.5rem",
-                  background: "linear-gradient(to right, #2dd4bf, #22d3ee)",
-                  color: "#060a14",
+                  background: "#00585d",
+                  color: "#ffffff",
                   fontWeight: 600,
                   borderRadius: "0.75rem",
                   border: "none",
@@ -110,10 +110,10 @@ export default function GlobalError({
                 style={{
                   padding: "0.75rem 1.5rem",
                   background: "transparent",
-                  color: "#ffffff",
+                  color: "#243c38",
                   fontWeight: 600,
                   borderRadius: "0.75rem",
-                  border: "1px solid rgba(255, 255, 255, 0.2)",
+                  border: "1px solid #6f8f88",
                   cursor: "pointer",
                   fontSize: "1rem",
                 }}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -2,6 +2,34 @@
 
 import { useEffect } from "react"
 
+const themeVariables = `
+  :root {
+    --bg: #ddebe6;
+    --panel: #f4fbf7;
+    --border: #6f8f88;
+    --accent-soft: #cceee6;
+    --accent-2: #9b352d;
+    --fg: #061513;
+    --muted: #243c38;
+    --accent: #00585d;
+    --on-accent: #ffffff;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #061311;
+      --panel: #10231f;
+      --border: #5f8179;
+      --accent-soft: #153b38;
+      --accent-2: #ff9b86;
+      --fg: #f4fffb;
+      --muted: #c1d4cf;
+      --accent: #7cf7e7;
+      --on-accent: #03110f;
+    }
+  }
+`
+
 export default function GlobalError({
   error,
   reset,
@@ -16,7 +44,10 @@ export default function GlobalError({
 
   return (
     <html lang="en">
-      <body style={{ margin: 0, backgroundColor: "#ddebe6" }}>
+      <head>
+        <style>{themeVariables}</style>
+      </head>
+      <body style={{ margin: 0, backgroundColor: "var(--bg)" }}>
         <div
           style={{
             minHeight: "100vh",
@@ -29,13 +60,13 @@ export default function GlobalError({
         >
           <div
             style={{
-              background: "#f4fbf7",
+              background: "var(--panel)",
               backdropFilter: "blur(20px)",
               borderRadius: "1rem",
               padding: "2rem",
               maxWidth: "28rem",
               textAlign: "center",
-              border: "1px solid #6f8f88",
+              border: "1px solid var(--border)",
             }}
           >
             <div
@@ -44,7 +75,7 @@ export default function GlobalError({
                 height: "4rem",
                 margin: "0 auto 1.5rem",
                 borderRadius: "50%",
-                background: "#cceee6",
+                background: "var(--accent-soft)",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
@@ -54,7 +85,7 @@ export default function GlobalError({
                 width="32"
                 height="32"
                 fill="none"
-                stroke="#9b352d"
+                stroke="var(--accent-2)"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
               >
@@ -71,7 +102,7 @@ export default function GlobalError({
               style={{
                 fontSize: "1.5rem",
                 fontWeight: "bold",
-                color: "#061513",
+                color: "var(--fg)",
                 marginBottom: "0.5rem",
               }}
             >
@@ -80,7 +111,7 @@ export default function GlobalError({
 
             <p
               style={{
-                color: "#243c38",
+                color: "var(--muted)",
                 marginBottom: "1.5rem",
                 lineHeight: 1.5,
               }}
@@ -93,8 +124,8 @@ export default function GlobalError({
                 onClick={reset}
                 style={{
                   padding: "0.75rem 1.5rem",
-                  background: "#00585d",
-                  color: "#ffffff",
+                  background: "var(--accent)",
+                  color: "var(--on-accent)",
                   fontWeight: 600,
                   borderRadius: "0.75rem",
                   border: "none",
@@ -110,10 +141,10 @@ export default function GlobalError({
                 style={{
                   padding: "0.75rem 1.5rem",
                   background: "transparent",
-                  color: "#243c38",
+                  color: "var(--muted)",
                   fontWeight: 600,
                   borderRadius: "0.75rem",
-                  border: "1px solid #6f8f88",
+                  border: "1px solid var(--border)",
                   cursor: "pointer",
                   fontSize: "1rem",
                 }}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,44 +1,59 @@
 import Link from "next/link"
+import { ThemeShell } from "@/components/theme-shell"
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#060a14] px-4">
-      <div className="glass rounded-2xl p-8 max-w-md text-center">
-        <div className="w-20 h-20 mx-auto mb-6 rounded-full bg-[#2dd4bf]/20 flex items-center justify-center">
-          <span className="text-4xl font-bold gradient-text">404</span>
-        </div>
-
-        <h1 className="text-2xl font-bold text-white mb-2">
-          Page not found
-        </h1>
-
-        <p className="text-white/60 mb-6">
-          The page you&apos;re looking for doesn&apos;t exist or has been moved.
-        </p>
-
-        <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <Link
-            href="/"
-            className="px-6 py-3 bg-gradient-to-r from-[#2dd4bf] to-[#22d3ee] text-[#060a14] font-semibold rounded-xl hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-[#2dd4bf] focus:ring-offset-2 focus:ring-offset-[#060a14]"
+    <ThemeShell>
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div
+          className="rounded-3xl border p-8 max-w-md text-center"
+          style={{
+            borderColor: "var(--dtz-border)",
+            background: "var(--dtz-panel)",
+            boxShadow: "var(--dtz-shadow)",
+          }}
+        >
+          <div
+            className="w-20 h-20 mx-auto mb-6 rounded-full flex items-center justify-center"
+            style={{ background: "var(--dtz-accent-soft)" }}
           >
-            Go home
-          </Link>
+            <span className="text-4xl font-bold" style={{ color: "var(--dtz-accent)" }}>
+              404
+            </span>
+          </div>
 
-          <Link
-            href="/#focus"
-            className="px-6 py-3 border border-white/20 text-white font-semibold rounded-xl hover:bg-white/5 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-[#060a14]"
-          >
-            View focus areas
-          </Link>
+          <h1 className="text-2xl font-bold mb-2">Page not found</h1>
+
+          <p className="mb-6" style={{ color: "var(--dtz-muted)" }}>
+            The page you&apos;re looking for doesn&apos;t exist or has been moved.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              href="/"
+              className="px-6 py-3 font-semibold rounded-xl transition-opacity hover:opacity-90"
+              style={{ background: "var(--dtz-accent)", color: "var(--dtz-on-accent)" }}
+            >
+              Go home
+            </Link>
+
+            <Link
+              href="/#notes"
+              className="px-6 py-3 border font-semibold rounded-xl transition-colors"
+              style={{ borderColor: "var(--dtz-border)", color: "var(--dtz-muted)" }}
+            >
+              Current focus
+            </Link>
+          </div>
+
+          <p className="mt-8 text-sm" style={{ color: "var(--dtz-muted)" }}>
+            Looking for something specific?{" "}
+            <Link href="/#contact" className="hover:underline" style={{ color: "var(--dtz-accent)" }}>
+              Get in touch
+            </Link>
+          </p>
         </div>
-
-        <p className="mt-8 text-white/75 text-sm">
-          Looking for something specific?{" "}
-          <Link href="/#contact" className="text-[#2dd4bf] hover:underline">
-            Get in touch
-          </Link>
-        </p>
       </div>
-    </div>
+    </ThemeShell>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,11 +2,11 @@
 
 import Image from "next/image"
 import Link from "next/link"
-import { useEffect, useState } from "react"
 import { motion, useReducedMotion } from "framer-motion"
 import { GithubIcon } from "@/components/icons/brand-icons"
 import { ProtectedWhatsAppLink } from "@/components/contact/protected-whatsapp-link"
 import { AIAssistant } from "@/components/ai-assistant"
+import { useSiteTheme } from "@/components/use-site-theme"
 import { contact, whatsappHref } from "@/data/content"
 import {
   ArrowUpRight,
@@ -141,39 +141,6 @@ const contactGuardrails = [
   "A future WhatsApp/n8n screener can label spam, ask one clarifying question, and keep human approval on replies.",
   "Direct calls should happen after context, not as the first public CTA bots can scrape.",
 ]
-
-function useSiteTheme() {
-  const [theme, setTheme] = useState<"light" | "dark">("light")
-
-  useEffect(() => {
-    const requestedTheme = new URLSearchParams(window.location.search).get("theme")
-    let nextTheme: "light" | "dark" | null = null
-
-    if (requestedTheme === "light" || requestedTheme === "dark") {
-      nextTheme = requestedTheme
-      window.localStorage.setItem("davidtiz-theme", requestedTheme)
-    } else {
-      const savedTheme = window.localStorage.getItem("davidtiz-theme")
-      if (savedTheme === "light" || savedTheme === "dark") {
-        nextTheme = savedTheme
-      } else if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
-        nextTheme = "dark"
-      }
-    }
-
-    if (!nextTheme) return
-
-    const frame = window.requestAnimationFrame(() => setTheme(nextTheme))
-    return () => window.cancelAnimationFrame(frame)
-  }, [])
-
-  const updateTheme = (nextTheme: "light" | "dark") => {
-    setTheme(nextTheme)
-    window.localStorage.setItem("davidtiz-theme", nextTheme)
-  }
-
-  return { theme, updateTheme }
-}
 
 export default function HomePage() {
   const { theme, updateTheme } = useSiteTheme()
@@ -521,6 +488,9 @@ export default function HomePage() {
           <a href={contact.github} target="_blank" rel="noreferrer">
             GitHub
           </a>
+          <Link href="/contact">All contact paths</Link>
+          <Link href="/portfolio">Portfolio</Link>
+          <Link href="/privacy">Privacy</Link>
         </span>
       </footer>
 

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -16,6 +16,7 @@ import {
 
 import { businessSiteUrl } from "@/lib/site-config";
 import { contact } from "@/data/content";
+import { ThemeShell } from "@/components/theme-shell";
 
 export const metadata: Metadata = {
   title: "Portfolio | David Ortiz",
@@ -118,285 +119,318 @@ const liveProofUpdates = [
   },
 ];
 
+const panelStyle = {
+  borderColor: "var(--dtz-border)",
+  background: "var(--dtz-panel)",
+} as const;
+const panelDeepStyle = {
+  borderColor: "var(--dtz-border)",
+  background: "var(--dtz-panel-2)",
+} as const;
+const iconChipStyle = {
+  background: "var(--dtz-accent-soft)",
+  color: "var(--dtz-accent)",
+} as const;
+const mutedText = { color: "var(--dtz-muted)" } as const;
+const primaryCtaStyle = {
+  background: "var(--dtz-accent)",
+  color: "var(--dtz-on-accent)",
+} as const;
+
 export default function PortfolioPage() {
   return (
-    <main className="min-h-screen bg-[#060a14] px-6 py-12 text-white">
-      <div className="mx-auto max-w-7xl">
-        <nav className="flex flex-wrap items-center justify-between gap-4">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/60 transition-colors hover:border-white/25 hover:text-white"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Back to home
-          </Link>
-          <a
-            href={`mailto:${contact.email}`}
-            className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#ff6b6b] to-[#ff8e8e] px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-[#ff6b6b]/10"
-          >
-            <Mail className="h-4 w-4" />
-            Contact David
-          </a>
-        </nav>
+    <ThemeShell>
+      <main className="min-h-screen px-6 py-12">
+        <div className="mx-auto max-w-7xl">
+          <nav className="flex flex-wrap items-center justify-between gap-4">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm transition-colors"
+              style={{ borderColor: "var(--dtz-border)", color: "var(--dtz-muted)" }}
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              Back to home
+            </Link>
+            <a
+              href={`mailto:${contact.email}`}
+              className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold"
+              style={primaryCtaStyle}
+            >
+              <Mail className="h-4 w-4" aria-hidden="true" />
+              Contact David
+            </a>
+          </nav>
 
-        <section className="grid gap-12 py-16 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[#2dd4bf]">
-              Portfolio
-            </p>
-            <h1 className="mt-5 text-4xl font-bold leading-tight md:text-6xl">
-              Real local-business work, starting with Hernandez Landscape
-            </h1>
-            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-white/55">
-              This page gives visitors a direct reference point. Hernandez
-              Landscape & Tree Service is a live landscaping website with
-              bilingual content, service positioning, project photos, and a
-              quote flow built around local customer calls, sourced trust
-              signals, and estimate requests.
-            </p>
-            <div className="mt-8 flex flex-col gap-4 sm:flex-row">
-              <a
-                href="https://hernandezlandscapeservices.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-[#7ac943] to-[#2dd4bf] px-6 py-3 font-semibold text-[#06140e] transition-transform hover:scale-[1.01]"
-              >
-                View live Hernandez site
-                <ExternalLink className="h-4 w-4" />
-              </a>
-              <a
-                href={`${businessSiteUrl}/projects/hernandez-landscape-local-business-site`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/10 px-6 py-3 font-semibold text-white/75 transition-colors hover:border-white/25 hover:text-white"
-              >
-                Read case note
-                <ArrowRight className="h-4 w-4" />
-              </a>
-            </div>
-          </div>
-
-          <div className="rounded-3xl border border-white/8 bg-[#08101e]/80 p-4 shadow-2xl shadow-black/30">
-            <Image
-              src="/portfolio/hernandez/site-screenshot.png"
-              alt="Screenshot of the Hernandez Landscape website"
-              width={1440}
-              height={1000}
-              className="h-auto w-full rounded-2xl border border-white/10"
-              priority
-            />
-          </div>
-        </section>
-
-        <section className="grid gap-4 pb-10 md:grid-cols-3">
-          {liveProofUpdates.map((item) => {
-            const Icon = item.icon;
-
-            return (
-              <article
-                key={item.title}
-                className="rounded-3xl border border-white/8 bg-white/[0.035] p-6"
-              >
-                <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#2dd4bf]/10 text-[#2dd4bf]">
-                  <Icon className="h-5 w-5" />
-                </span>
-                <h2 className="mt-5 text-lg font-semibold text-white">
-                  {item.title}
-                </h2>
-                <p className="mt-3 text-sm leading-relaxed text-white/50">
-                  {item.description}
-                </p>
-              </article>
-            );
-          })}
-        </section>
-
-        <section className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
-          <div className="rounded-3xl border border-white/8 bg-white/[0.03] p-6">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#b8f28e]">
-              What the example shows
-            </p>
-            <div className="mt-6 space-y-4">
-              {highlights.map((highlight) => (
-                <div key={highlight} className="flex gap-3">
-                  <span className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-[#7ac943]" />
-                  <p className="text-sm leading-relaxed text-white/65">
-                    {highlight}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-3">
-            {packageExamples.map((item) => (
-              <article
-                key={item.title}
-                className="rounded-3xl border border-white/8 bg-white/[0.03] p-6"
-              >
-                <h2 className="text-lg font-semibold text-white">
-                  {item.title}
-                </h2>
-                <p className="mt-3 text-sm leading-relaxed text-white/50">
-                  {item.description}
-                </p>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="grid gap-6 py-16 lg:grid-cols-[1.05fr_0.95fr]">
-          <div className="rounded-3xl border border-white/8 bg-[#08101e]/80 p-6 md:p-8">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#2dd4bf]">
-              Reference links
-            </p>
-            <h2 className="mt-4 text-2xl font-bold md:text-3xl">
-              Each link answers a different question about the work.
-            </h2>
-            <div className="mt-6 grid gap-4">
-              {referenceLinks.map((item) => {
-                const Icon = item.icon;
-
-                return (
-                  <a
-                    key={item.href}
-                    href={item.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="group flex items-start gap-4 rounded-2xl border border-white/8 bg-white/[0.035] p-4 transition-colors hover:border-[#2dd4bf]/40 hover:bg-white/[0.06]"
-                  >
-                    <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-[#2dd4bf]/10 text-[#2dd4bf]">
-                      <Icon className="h-5 w-5" />
-                    </span>
-                    <span>
-                      <span className="flex items-center gap-2 text-sm font-semibold text-white">
-                        {item.title}
-                        <ArrowRight className="h-4 w-4 text-white/30 transition-transform group-hover:translate-x-0.5" />
-                      </span>
-                      <span className="mt-1 block text-sm leading-relaxed text-white/50">
-                        {item.description}
-                      </span>
-                    </span>
-                  </a>
-                );
-              })}
-            </div>
-          </div>
-
-          <div className="rounded-3xl border border-white/8 bg-white/[0.03] p-6 md:p-8">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#b8f28e]">
-              Build signals
-            </p>
-            <h2 className="mt-4 text-2xl font-bold md:text-3xl">
-              Concrete stack, not placeholder labels.
-            </h2>
-            <p className="mt-4 text-sm leading-relaxed text-white/50">
-              Clients do not need the whole implementation story, but they
-              should see that the site was built with real production pieces and
-              not just a static mockup.
-            </p>
-            <div className="mt-6 grid gap-3">
-              {stackSignals.map((signal) => (
-                <div
-                  key={signal}
-                  className="flex items-center gap-3 rounded-2xl border border-white/8 bg-[#0b1424]/75 px-4 py-3"
+          <section className="grid gap-12 py-16 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
+            <div>
+              <p className="dtz-section-label">Portfolio</p>
+              <h1 className="mt-5 text-4xl font-bold leading-tight md:text-6xl">
+                Real local-business work, starting with Hernandez Landscape
+              </h1>
+              <p className="mt-6 max-w-2xl text-lg leading-relaxed" style={mutedText}>
+                This page gives visitors a direct reference point. Hernandez
+                Landscape & Tree Service is a live landscaping website with
+                bilingual content, service positioning, project photos, and a
+                quote flow built around local customer calls, sourced trust
+                signals, and estimate requests.
+              </p>
+              <div className="mt-8 flex flex-col gap-4 sm:flex-row">
+                <a
+                  href="https://hernandezlandscapeservices.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl px-6 py-3 font-semibold transition-transform hover:scale-[1.01]"
+                  style={primaryCtaStyle}
                 >
-                  <CheckCircle2 className="h-4 w-4 shrink-0 text-[#7ac943]" />
-                  <span className="text-sm text-white/65">{signal}</span>
-                </div>
+                  View live Hernandez site
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                </a>
+                <a
+                  href={`${businessSiteUrl}/projects/hernandez-landscape-local-business-site`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl border px-6 py-3 font-semibold transition-colors"
+                  style={{ borderColor: "var(--dtz-border)", color: "var(--dtz-muted)" }}
+                >
+                  Read case note
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </a>
+              </div>
+            </div>
+
+            <div
+              className="rounded-3xl border p-4"
+              style={{ ...panelStyle, boxShadow: "var(--dtz-shadow)" }}
+            >
+              <Image
+                src="/portfolio/hernandez/site-screenshot.png"
+                alt="Screenshot of the Hernandez Landscape website"
+                width={1440}
+                height={1000}
+                className="h-auto w-full rounded-2xl border"
+                style={{ borderColor: "var(--dtz-border)" }}
+                priority
+              />
+            </div>
+          </section>
+
+          <section className="grid gap-4 pb-10 md:grid-cols-3">
+            {liveProofUpdates.map((item) => {
+              const Icon = item.icon;
+
+              return (
+                <article key={item.title} className="rounded-3xl border p-6" style={panelStyle}>
+                  <span
+                    className="flex h-11 w-11 items-center justify-center rounded-2xl"
+                    style={iconChipStyle}
+                  >
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <h2 className="mt-5 text-lg font-semibold">{item.title}</h2>
+                  <p className="mt-3 text-sm leading-relaxed" style={mutedText}>
+                    {item.description}
+                  </p>
+                </article>
+              );
+            })}
+          </section>
+
+          <section className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
+            <div className="rounded-3xl border p-6" style={panelStyle}>
+              <p className="dtz-section-label">What the example shows</p>
+              <div className="mt-6 space-y-4">
+                {highlights.map((highlight) => (
+                  <div key={highlight} className="flex gap-3">
+                    <span
+                      className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full"
+                      style={{ background: "var(--dtz-accent)" }}
+                    />
+                    <p className="text-sm leading-relaxed" style={mutedText}>
+                      {highlight}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-3">
+              {packageExamples.map((item) => (
+                <article key={item.title} className="rounded-3xl border p-6" style={panelStyle}>
+                  <h2 className="text-lg font-semibold">{item.title}</h2>
+                  <p className="mt-3 text-sm leading-relaxed" style={mutedText}>
+                    {item.description}
+                  </p>
+                </article>
               ))}
             </div>
-          </div>
-        </section>
+          </section>
 
-        <section className="grid gap-6 py-16 lg:grid-cols-3">
-          <div className="overflow-hidden rounded-3xl border border-white/8 bg-white/[0.03]">
-            <Image
-              src="/portfolio/hernandez/landscape-work-hero.jpeg"
-              alt="Landscaping project photo used for Hernandez Landscape"
-              width={1600}
-              height={1000}
-              loading="eager"
-              className="aspect-[16/10] w-full object-cover"
-            />
-            <div className="p-6">
-              <h2 className="text-lg font-semibold">Real project imagery</h2>
-              <p className="mt-2 text-sm leading-relaxed text-white/50">
-                The site uses real work photos instead of generic stock imagery,
-                so prospects can inspect the type of landscaping work the
-                business actually performs.
-              </p>
-            </div>
-          </div>
-
-          <div className="overflow-hidden rounded-3xl border border-white/8 bg-white/[0.03]">
-            <Image
-              src="/portfolio/hernandez/site-trust-screenshot.png"
-              alt="Sourced customer feedback section from the Hernandez Landscape website"
-              width={1440}
-              height={729}
-              loading="eager"
-              className="aspect-[16/10] w-full object-cover object-top"
-            />
-            <div className="p-6">
-              <h2 className="text-lg font-semibold">Sourced trust section</h2>
-              <p className="mt-2 text-sm leading-relaxed text-white/50">
-                The trust section now points to a public review source, keeping
-                the sales page credible and easy to defend.
-              </p>
-            </div>
-          </div>
-
-          <div className="overflow-hidden rounded-3xl border border-white/8 bg-white/[0.03]">
-            <Image
-              src="/portfolio/hernandez/sergio-landscaping-marketing-clean.png"
-              alt="Clean marketing visual for landscaping and snow removal outreach"
-              width={1080}
-              height={1080}
-              loading="eager"
-              className="aspect-square w-full object-cover"
-            />
-            <div className="p-6">
-              <h2 className="text-lg font-semibold">
-                Clean outreach collateral
+          <section className="grid gap-6 py-16 lg:grid-cols-[1.05fr_0.95fr]">
+            <div className="rounded-3xl border p-6 md:p-8" style={panelStyle}>
+              <p className="dtz-section-label">Reference links</p>
+              <h2 className="mt-4 text-2xl font-bold md:text-3xl">
+                Each link answers a different question about the work.
               </h2>
-              <p className="mt-2 text-sm leading-relaxed text-white/50">
-                The share image is built with clean rendered text, avoiding
-                distorted lettering when it is sent through Messenger or social
-                DMs.
-              </p>
-            </div>
-          </div>
-        </section>
+              <div className="mt-6 grid gap-4">
+                {referenceLinks.map((item) => {
+                  const Icon = item.icon;
 
-        <section className="pb-12">
-          <div className="rounded-3xl border border-[#2dd4bf]/20 bg-[#2dd4bf]/10 p-6 md:p-8">
-            <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#9ae6db]">
-                  Next step
-                </p>
-                <h2 className="mt-3 text-2xl font-bold">
-                  Want something like this for your local business?
-                </h2>
-                <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/55">
-                  Use the services-facing contact flow for formal scoping,
-                  project questions, and local-business delivery.
+                  return (
+                    <a
+                      key={item.href}
+                      href={item.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group flex items-start gap-4 rounded-2xl border p-4 transition-colors"
+                      style={panelDeepStyle}
+                    >
+                      <span
+                        className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl"
+                        style={iconChipStyle}
+                      >
+                        <Icon className="h-5 w-5" aria-hidden="true" />
+                      </span>
+                      <span>
+                        <span className="flex items-center gap-2 text-sm font-semibold">
+                          {item.title}
+                          <ArrowRight
+                            className="h-4 w-4 transition-transform group-hover:translate-x-0.5"
+                            style={{ color: "var(--dtz-subtle)" }}
+                            aria-hidden="true"
+                          />
+                        </span>
+                        <span className="mt-1 block text-sm leading-relaxed" style={mutedText}>
+                          {item.description}
+                        </span>
+                      </span>
+                    </a>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="rounded-3xl border p-6 md:p-8" style={panelStyle}>
+              <p className="dtz-section-label">Build signals</p>
+              <h2 className="mt-4 text-2xl font-bold md:text-3xl">
+                Concrete stack, not placeholder labels.
+              </h2>
+              <p className="mt-4 text-sm leading-relaxed" style={mutedText}>
+                Clients do not need the whole implementation story, but they
+                should see that the site was built with real production pieces and
+                not just a static mockup.
+              </p>
+              <div className="mt-6 grid gap-3">
+                {stackSignals.map((signal) => (
+                  <div
+                    key={signal}
+                    className="flex items-center gap-3 rounded-2xl border px-4 py-3"
+                    style={panelDeepStyle}
+                  >
+                    <CheckCircle2
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--dtz-accent)" }}
+                      aria-hidden="true"
+                    />
+                    <span className="text-sm" style={mutedText}>
+                      {signal}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-6 py-16 lg:grid-cols-3">
+            <div className="overflow-hidden rounded-3xl border" style={panelStyle}>
+              <Image
+                src="/portfolio/hernandez/landscape-work-hero.jpeg"
+                alt="Landscaping project photo used for Hernandez Landscape"
+                width={1600}
+                height={1000}
+                loading="eager"
+                className="aspect-[16/10] w-full object-cover"
+              />
+              <div className="p-6">
+                <h2 className="text-lg font-semibold">Real project imagery</h2>
+                <p className="mt-2 text-sm leading-relaxed" style={mutedText}>
+                  The site uses real work photos instead of generic stock imagery,
+                  so prospects can inspect the type of landscaping work the
+                  business actually performs.
                 </p>
               </div>
-              <a
-                href={`${businessSiteUrl}/contact`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-[#2dd4bf] to-[#22d3ee] px-6 py-3 font-semibold text-[#06140e] transition-transform hover:scale-[1.01]"
-              >
-                Start a project
-                <ArrowRight className="h-4 w-4" />
-              </a>
             </div>
-          </div>
-        </section>
-      </div>
-    </main>
+
+            <div className="overflow-hidden rounded-3xl border" style={panelStyle}>
+              <Image
+                src="/portfolio/hernandez/site-trust-screenshot.png"
+                alt="Sourced customer feedback section from the Hernandez Landscape website"
+                width={1440}
+                height={729}
+                loading="eager"
+                className="aspect-[16/10] w-full object-cover object-top"
+              />
+              <div className="p-6">
+                <h2 className="text-lg font-semibold">Sourced trust section</h2>
+                <p className="mt-2 text-sm leading-relaxed" style={mutedText}>
+                  The trust section now points to a public review source, keeping
+                  the sales page credible and easy to defend.
+                </p>
+              </div>
+            </div>
+
+            <div className="overflow-hidden rounded-3xl border" style={panelStyle}>
+              <Image
+                src="/portfolio/hernandez/sergio-landscaping-marketing-clean.png"
+                alt="Clean marketing visual for landscaping and snow removal outreach"
+                width={1080}
+                height={1080}
+                loading="eager"
+                className="aspect-square w-full object-cover"
+              />
+              <div className="p-6">
+                <h2 className="text-lg font-semibold">
+                  Clean outreach collateral
+                </h2>
+                <p className="mt-2 text-sm leading-relaxed" style={mutedText}>
+                  The share image is built with clean rendered text, avoiding
+                  distorted lettering when it is sent through Messenger or social
+                  DMs.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className="pb-12">
+            <div
+              className="rounded-3xl border p-6 md:p-8"
+              style={{ borderColor: "var(--dtz-border)", background: "var(--dtz-accent-soft)" }}
+            >
+              <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="dtz-section-label">Next step</p>
+                  <h2 className="mt-3 text-2xl font-bold">
+                    Want something like this for your local business?
+                  </h2>
+                  <p className="mt-2 max-w-2xl text-sm leading-relaxed" style={mutedText}>
+                    Use the services-facing contact flow for formal scoping,
+                    project questions, and local-business delivery.
+                  </p>
+                </div>
+                <a
+                  href={`${businessSiteUrl}/contact`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl px-6 py-3 font-semibold transition-transform hover:scale-[1.01]"
+                  style={primaryCtaStyle}
+                >
+                  Start a project
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </a>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </ThemeShell>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import type { Metadata } from "next"
+import { ThemeShell } from "@/components/theme-shell"
 
 export const metadata: Metadata = {
   title: "Privacy Policy | David Ortiz",
@@ -17,7 +18,8 @@ const wrapper: React.CSSProperties = {
 
 export default function PrivacyPage() {
   return (
-    <main style={wrapper}>
+    <ThemeShell>
+      <main style={wrapper}>
       <h1>Privacy Policy</h1>
       <p>
         <em>Effective date: June 4, 2026</em>
@@ -82,6 +84,7 @@ export default function PrivacyPage() {
       <p>
         <Link href="/">&larr; Back to davidtiz.com</Link>
       </p>
-    </main>
+      </main>
+    </ThemeShell>
   )
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next"
+
+// proxy.ts already exempts /robots.txt from the host-canonicalization
+// middleware in anticipation of this file existing.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/admin/",
+          "/api/",
+          "/contact/whatsapp", // screened redirect + challenge endpoint, not content
+          "/pay", // already noindex via page metadata
+          "/pagar",
+        ],
+      },
+    ],
+    sitemap: "https://davidtiz.com/sitemap.xml",
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next"
+
+const BASE_URL = "https://davidtiz.com"
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: `${BASE_URL}/`, changeFrequency: "monthly", priority: 1 },
+    { url: `${BASE_URL}/contact`, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${BASE_URL}/portfolio`, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${BASE_URL}/demo`, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${BASE_URL}/privacy`, changeFrequency: "yearly", priority: 0.2 },
+  ]
+}

--- a/components/theme-shell.tsx
+++ b/components/theme-shell.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { useSiteTheme } from "@/components/use-site-theme"
+
+// Wraps secondary pages (contact, portfolio, privacy, 404, error) in the
+// same `.dtz-site` scope as the homepage, so the dtz-* design tokens cascade
+// and the saved light/dark preference applies site-wide instead of only on
+// the homepage. Pages style themselves with var(--dtz-*) on top of this.
+export function ThemeShell({ children }: { children: ReactNode }) {
+  const { theme } = useSiteTheme()
+
+  return <div className={`dtz-site dtz-${theme}`}>{children}</div>
+}

--- a/components/use-site-theme.ts
+++ b/components/use-site-theme.ts
@@ -1,0 +1,39 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+// Single source of truth for the site theme: honors ?theme=, then the
+// davidtiz-theme localStorage key, then prefers-color-scheme. Used by the
+// homepage (which also renders the toggle) and by ThemeShell for subpages.
+export function useSiteTheme() {
+  const [theme, setTheme] = useState<"light" | "dark">("light")
+
+  useEffect(() => {
+    const requestedTheme = new URLSearchParams(window.location.search).get("theme")
+    let nextTheme: "light" | "dark" | null = null
+
+    if (requestedTheme === "light" || requestedTheme === "dark") {
+      nextTheme = requestedTheme
+      window.localStorage.setItem("davidtiz-theme", requestedTheme)
+    } else {
+      const savedTheme = window.localStorage.getItem("davidtiz-theme")
+      if (savedTheme === "light" || savedTheme === "dark") {
+        nextTheme = savedTheme
+      } else if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
+        nextTheme = "dark"
+      }
+    }
+
+    if (!nextTheme) return
+
+    const frame = window.requestAnimationFrame(() => setTheme(nextTheme))
+    return () => window.cancelAnimationFrame(frame)
+  }, [])
+
+  const updateTheme = (nextTheme: "light" | "dark") => {
+    setTheme(nextTheme)
+    window.localStorage.setItem("davidtiz-theme", nextTheme)
+  }
+
+  return { theme, updateTheme }
+}


### PR DESCRIPTION
Full-site design audit + overhaul. The homepage spoke the `dtz-*` sage/teal language while **/contact, /portfolio, 404, error, and global-error still wore the old dark-neon palette** (`#060a14`/`#2dd4bf`) that CLAUDE.md explicitly rules out ('not cyberpunk/agency') — and several pages were unreachable from the site at all.

## Design coherence
- **New `components/use-site-theme.ts`** (hook extracted from the homepage, zero behavior change) + **`components/theme-shell.tsx`**: secondary pages render inside the same `.dtz-site` scope, so the design tokens cascade and the saved **light/dark preference finally applies site-wide** instead of homepage-only.
- **/contact, /portfolio, 404, error** re-skinned onto `var(--dtz-*)` tokens — structure, content, and every link preserved exactly; only the palette changed (same pattern the AI assistant already uses).
- **global-error** uses lightweight inline CSS variables with `prefers-color-scheme` support, because it replaces the root layout and cannot depend on normal site CSS variables.
- **/privacy** wrapped in ThemeShell so the legal page inherits brand colors + theming.
- **/pay deliberately unchanged**: its warm 'tianguis' palette is a coherent sub-brand paired with the `public/demo` pages it links to (Spanish local-business funnel).

## Structural holes closed
- **Orphan pages**: the homepage linked to no secondary page. Footer now links **/contact** (where the new YouTube/Twitch/X links live), **/portfolio**, and **/privacy** (a Meta-app requirement that was unreachable).
- **Dead anchor**: 404 page linked to `/#focus`, which doesn't exist → now `/#notes`.
- **SEO**: `robots.txt` and `sitemap.xml` were 404 in production (`proxy.ts` already carved them out in anticipation). Added `app/robots.ts` + `app/sitemap.ts` — robots disallows `/admin/`, `/api/`, the `/contact/whatsapp` redirect, and the noindex `/pay` routes.

## Review follow-up
- Addressed Gemini's global-error feedback so dark-mode users do not see a forced bright fallback during root-level errors.

## Validation
- 41/41 tests, lint clean, build green (robots/sitemap appear in the route list).
- `next start` smoke test: `dtz-site` wrapper confirmed in served HTML on /contact, /portfolio, /privacy, and the 404 page; robots/sitemap serving; footer links present; **zero dark-neon hex remnants** anywhere in `app/` or served HTML.

## ⚠️ Recommend eyeballing the Vercel preview before merging
This is a visual change across five pages and merging auto-deploys. Worth a 2-minute look at the preview deployment (both themes — add `?theme=dark`) before it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)