### PR TITLE
feat: baseline security headers + guard tests for SEO config

### DIFF
--- a/app/seo-config.test.ts
+++ b/app/seo-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import robots from "@/app/robots"
+import sitemap from "@/app/sitemap"
+import nextConfig from "@/next.config.mjs"
+
+// These guard the SEO/hardening config against accidental edits: removing a
+// disallow line or a header here is a deliberate decision, not a side effect.
+
+describe("robots.txt config", () => {
+  const config = robots()
+  const rule = Array.isArray(config.rules) ? config.rules[0] : config.rules
+
+  it("keeps crawlers off the operational routes", () => {
+    const disallow = Array.isArray(rule.disallow) ? rule.disallow : [rule.disallow]
+    for (const path of ["/admin/", "/api/", "/contact/whatsapp", "/pay", "/pagar"]) {
+      expect(disallow).toContain(path)
+    }
+  })
+
+  it("allows the rest of the site and names the sitemap", () => {
+    expect(rule.allow).toBe("/")
+    expect(config.sitemap).toBe("https://davidtiz.com/sitemap.xml")
+  })
+})
+
+describe("sitemap", () => {
+  const urls = sitemap().map((entry) => entry.url)
+
+  it("lists exactly the public content pages", () => {
+    expect(urls).toEqual([
+      "https://davidtiz.com/",
+      "https://davidtiz.com/contact",
+      "https://davidtiz.com/portfolio",
+      "https://davidtiz.com/demo",
+      "https://davidtiz.com/privacy",
+    ])
+  })
+
+  it("never lists noindex or operational routes", () => {
+    for (const url of urls) {
+      expect(url).not.toMatch(/\/(pay|pagar|admin|api|contact\/whatsapp)/)
+    }
+  })
+})
+
+describe("security headers", () => {
+  it("applies the baseline hardening set to every route", async () => {
+    const headerRules = await nextConfig.headers()
+    const all = headerRules.find((entry) => entry.source === "/(.*)")
+    expect(all).toBeDefined()
+
+    const byKey = Object.fromEntries(all.headers.map((header) => [header.key, header.value]))
+    expect(byKey["X-Content-Type-Options"]).toBe("nosniff")
+    expect(byKey["X-Frame-Options"]).toBe("DENY")
+    expect(byKey["Referrer-Policy"]).toBe("strict-origin-when-cross-origin")
+    expect(byKey["Permissions-Policy"]).toContain("camera=()")
+  })
+})

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,22 @@ const nextConfig = {
       },
     ]
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          // Baseline hardening. No CSP yet: the site uses inline styles
+          // heavily (dtz tokens via style={}), so a strict CSP needs nonces
+          // and its own change.
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Security headers
`headers()` in `next.config.mjs` now applies to every route (pages **and** API handlers — verified at runtime against `next start`):
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`

Deliberately **no CSP yet**: the dtz token styling relies on inline `style` attributes everywhere, so a strict CSP needs nonce plumbing and deserves its own PR.

## Guard tests (5 new, 46 total)
`app/seo-config.test.ts` locks the config that's easy to break silently:
- robots keeps `/admin/`, `/api/`, `/contact/whatsapp`, `/pay`, `/pagar` disallowed
- sitemap lists **exactly** the five public pages and never an operational/noindex route
- the header baseline stays applied to `/(.*)`

Build/lint/tests green; headers confirmed serving at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)