### PR TITLE
docs: strengthen Hernandez portfolio claims post lead-flow fix

### DIFF
--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
 
 const highlights = [
   "Bilingual English and Spanish paths",
-  "Instant estimate and prefilled quote capture flow",
+  "Instant estimator that pre-fills the full quote request — address, owner confirmation, callback time, service, and estimate range — into the lead form",
   "Service pages for lawn care, tree service, landscaping, and snow removal",
   "Project gallery, sourced public review, and local service-area content",
 ];
@@ -93,7 +93,7 @@ const stackSignals = [
   "HTML, CSS, and JavaScript",
   "Vanilla bilingual i18n",
   "Web3Forms lead capture",
-  "Service-to-quote prefill behavior",
+  "Estimator and service-to-quote prefill",
   "Responsive service-card layout",
   "Local SEO and service-area copy",
 ];
@@ -106,9 +106,9 @@ const liveProofUpdates = [
     icon: Star,
   },
   {
-    title: "Better quote intent",
+    title: "Estimate-to-form handoff",
     description:
-      "Service chips now send visitors into the form with the relevant service already selected.",
+      "After the instant estimate, a Send My Estimate Request button now pre-fills the quote form with the address, owner confirmation, callback time, service, and estimate summary, in English and Spanish.",
     icon: MousePointerClick,
   },
   {
@@ -172,7 +172,8 @@ export default function PortfolioPage() {
                 Landscape & Tree Service is a live landscaping website with
                 bilingual content, service positioning, project photos, and a
                 quote flow built around local customer calls, sourced trust
-                signals, and estimate requests.
+                signals, and estimate requests that carry straight into the
+                contact form.
               </p>
               <div className="mt-8 flex flex-col gap-4 sm:flex-row">
                 <a


### PR DESCRIPTION
## Summary

Copy-only update to `app/portfolio/page.tsx` so the Hernandez case describes the shipped lead-flow behavior (hernandezlandscapeservices PR #21, live in production 2026-06-10):

- Highlights: 'Instant estimate and prefilled quote capture flow' -> 'Instant estimator that pre-fills the full quote request — address, owner confirmation, callback time, service, and estimate range — into the lead form'
- Build signals: 'Service-to-quote prefill behavior' -> 'Estimator and service-to-quote prefill'
- Live-proof card retitled 'Estimate-to-form handoff' with an accurate EN/ES description of the Send My Estimate Request flow
- Hero paragraph now notes estimate requests 'carry straight into the contact form'

Claims were verified against the shipped code (`assets/js/main.js` handoff logic and `tests/e2e/instant-estimate.spec.ts`) before writing copy. No links added; brand boundary untouched.

## Follow-up

Screenshot refresh of the estimator result box showing the new 'Send My Estimate Request' CTA is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)