### PR TITLE
Refresh public identity copy

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -79,11 +79,11 @@ const workAreas = [
   },
   {
     label: "Safety",
-    title: "Prompt Safety Learning",
-    body: "Ongoing study of AI guardrails, prompt injection, misuse boundaries, and the practical checks needed before an AI-powered workflow should be trusted.",
+    title: "AI Security and Prompt Defense",
+    body: "Practical work on prompt injection, instruction boundaries, misuse resistance, and the checks needed before an AI-powered workflow should be trusted.",
     image: "/visuals/ai-guardrails.svg",
     icon: ShieldCheck,
-    tags: ["Guardrails", "Testing", "Scope", "Review"],
+    tags: ["Prompt defense", "Guardrails", "Testing", "Review"],
   },
 ]
 
@@ -132,7 +132,7 @@ const stackGroups = [
 const currentFocus = [
   "Cleaner local-business websites with quote, order, or contact flows that do not feel overbuilt.",
   "Repeatable AI-assisted delivery: research, implementation, review, browser QA, and a written handoff.",
-  "Security-aware AI workflow habits, especially prompt injection, tool boundaries, and validation.",
+  "AI-security workflow habits, especially prompt injection, tool boundaries, and validation.",
   "Better notes that preserve what worked, what failed, and what should happen in the next session.",
 ]
 

--- a/data/content.ts
+++ b/data/content.ts
@@ -39,10 +39,10 @@ export const services: Service[] = [
     },
   },
   {
-    title: 'Prompt Safety',
+    title: 'AI Security and Prompt Defense',
     description:
-      'Notes on prompt injection, misuse resistance, and the practical failure modes that show up in AI-assisted workflows.',
-    bullets: ['Prompt defense', 'Attack surfaces', 'Safer delivery'],
+      'Notes on prompt injection, instruction boundaries, misuse resistance, and the practical failure modes that show up in AI-assisted workflows.',
+    bullets: ['Prompt defense', 'Instruction boundaries', 'Safer delivery'],
     icon: '🛡️',
     cta: {
       label: 'Read the security notes',

--- a/lib/contact-links.ts
+++ b/lib/contact-links.ts
@@ -10,7 +10,7 @@ export const socialProfileLinks = [
   "https://www.youtube.com/@razonlab",
   "https://www.twitch.tv/razonlab",
   "https://x.com/Razonapp",
-  "https://www.linkedin.com/in/david-ortiz-210190205/",
+  "https://www.linkedin.com/in/davidortiz-dekalb/",
   "https://www.facebook.com/profile.php?id=61581646236939",
   "https://www.instagram.com/ra.z.on",
 ] as const
@@ -91,7 +91,7 @@ export const followWorkLinks: ContactLink[] = [
   {
     id: "linkedin",
     label: "LinkedIn",
-    href: "https://www.linkedin.com/in/david-ortiz-210190205/",
+    href: "https://www.linkedin.com/in/davidortiz-dekalb/",
     description: "Professional profile, background, and another clean way to connect.",
   },
 ]


### PR DESCRIPTION
## Summary
- update the public portfolio AI-security wording from weak prompt-safety learning language to practical prompt-defense framing
- replace the old LinkedIn profile URL with the canonical davidortiz-dekalb URL
- avoid adding new cross-property links, preserving the current brand-boundary rules

## Verification
- npm run lint
- npm test
- npm run build

Note: this branch intentionally excludes existing local WhatsApp worktree changes.