### PR TITLE
feat(design): Warm Operator type pairing + command-center hero

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ CI (`.github/workflows/ci.yml`) runs lint → test → build on every push/PR; C
 ## Tech Stack
 - Framework: Next.js 16 (App Router)
 - UI: React 19, Tailwind CSS 4, Framer Motion
-- Fonts: Geist Sans & Geist Mono (`next/font`)
+- Fonts: Geist Sans (body), Geist Mono (labels/status), Fraunces serif display for H1/H2 (`next/font`)
 - Analytics: Vercel Analytics
 - Deployment: Vercel
 
@@ -69,8 +69,8 @@ Canonical boundary guidance lives in [`docs/ARCHITECTURE-BOUNDARIES.md`](docs/AR
 Short version: this app is intentionally small, so do not over-abstract; but do not let business/security rules drift further into framework files without characterization tests. For the WhatsApp redirect lane, preserve challenge validation, full challenge value integrity, replay blocking, sanitization, and redirect message behavior.
 
 ## Homepage sections (`app/page.tsx`)
-1. Header — brand, nav (Start / Work / About / Notes / Contact), light/dark toggle
-2. Hero — positioning + CTAs (See selected work, Message me on WhatsApp)
+1. Header — brand + "Technical Systems Builder" role label, nav (Work / Notes / Process / Contact), light/dark toggle
+2. Hero — command-center hero per `docs/IDENTITY-AND-DESIGN-DIRECTION.md`: mono clay eyebrow, serif headline, CTAs (See the systems / How I work), NOW + LAST SHIPPED status strip (data in `data/content.ts` → `heroStatus`)
 3. Selected Work — category cards (local business sites, AI workflow, RAG, automation, prompt safety)
 4. About / Operating Style — how David works
 5. Stack — tools he reaches for

--- a/app/globals.css
+++ b/app/globals.css
@@ -819,12 +819,13 @@ body {
   padding-block: clamp(3rem, 8vw, 6rem);
 }
 
-.dtz-section-label,
-.dtz-card-label {
+.dtz-site .dtz-section-label,
+.dtz-site .dtz-card-label {
   color: var(--dtz-accent);
-  font-size: 0.83rem;
-  font-weight: 850;
-  letter-spacing: 0.04em;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
@@ -1636,9 +1637,10 @@ body {
 
 .dtz-contact-card span {
   color: var(--dtz-accent);
-  font-size: 0.78rem;
-  font-weight: 850;
-  letter-spacing: 0.04em;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
@@ -1923,9 +1925,10 @@ body {
   border-radius: 8px;
   background: var(--dtz-accent-soft);
   color: var(--dtz-accent);
-  font-size: 0.76rem;
-  font-weight: 850;
-  letter-spacing: 0.04em;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
@@ -1969,8 +1972,9 @@ body {
   border: 1px solid var(--dtz-border);
   border-radius: 8px;
   color: var(--dtz-subtle);
-  font-size: 0.78rem;
-  font-weight: 760;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
 }
 
 .dtz-process-grid {

--- a/app/globals.css
+++ b/app/globals.css
@@ -811,14 +811,6 @@ body {
   color: var(--dtz-on-accent);
 }
 
-.dtz-hero {
-  display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(380px, 1.05fr);
-  gap: clamp(2rem, 5vw, 5rem);
-  align-items: center;
-  padding-block: clamp(3rem, 8vw, 6rem);
-}
-
 .dtz-site .dtz-section-label,
 .dtz-site .dtz-card-label {
   color: var(--dtz-accent);
@@ -1508,9 +1500,19 @@ body {
   }
 }
 
+/* Scroll-reveal styles are inline (framer-motion); force content visible on paper */
+@media print {
+  .dtz-hero-copy,
+  .dtz-proof-surface,
+  .dtz-setup-card,
+  .dtz-work-card {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+
 /* Warm Operator command-center hero */
 .dtz-command-hero {
-  display: block;
   padding-block: clamp(3.2rem, 9vw, 6.5rem);
 }
 
@@ -1595,12 +1597,6 @@ body {
   }
   50% {
     opacity: 0.35;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .dtz-status-dot {
-    animation: none;
   }
 }
 
@@ -1719,6 +1715,8 @@ body {
 }
 
 .dtz-proof-surface:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--dtz-accent) 70%, var(--dtz-border));
   box-shadow: 0 24px 64px color-mix(in srgb, var(--dtz-panel-dark) 20%, transparent);
 }
 
@@ -1728,6 +1726,20 @@ body {
   aspect-ratio: 16 / 8.6;
   border-bottom: 1px solid var(--dtz-border);
   background: var(--dtz-panel-dark);
+}
+
+.dtz-proof-surface-media img {
+  width: 100% !important;
+  height: 100% !important;
+  object-fit: cover;
+  transition:
+    transform 260ms ease,
+    filter 260ms ease;
+}
+
+.dtz-proof-surface:hover img {
+  filter: saturate(1.08) contrast(1.04);
+  transform: scale(1.025);
 }
 
 .dtz-proof-surface.is-featured .dtz-proof-surface-media {
@@ -1752,6 +1764,29 @@ body {
   margin: 0;
   color: var(--dtz-muted);
   line-height: 1.58;
+}
+
+.dtz-proof-surface-copy span {
+  color: var(--dtz-accent);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.dtz-proof-surface-copy a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.38rem;
+  color: var(--dtz-accent);
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.dtz-proof-surface-copy svg {
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
 .dtz-services-section {
@@ -2150,12 +2185,6 @@ body {
     grid-template-columns: 1fr;
   }
 
-}
-
-@media (max-width: 900px) {
-  .dtz-hero {
-    grid-template-columns: 1fr;
-  }
 }
 
 @media (max-width: 760px) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -42,6 +42,7 @@
   /* Font families */
   --font-sans: var(--font-geist-sans), system-ui, sans-serif;
   --font-mono: var(--font-geist-mono), "JetBrains Mono", monospace;
+  --font-serif: var(--font-fraunces), "Iowan Old Style", Georgia, serif;
 
   /* Brand colors */
   --cs-navy: #060a14;
@@ -818,7 +819,6 @@ body {
   padding-block: clamp(3rem, 8vw, 6rem);
 }
 
-.dtz-kicker,
 .dtz-section-label,
 .dtz-card-label {
   color: var(--dtz-accent);
@@ -828,33 +828,16 @@ body {
   text-transform: uppercase;
 }
 
-.dtz-kicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin: 0 0 1.25rem;
-  padding: 0.55rem 0.7rem;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  background: var(--dtz-panel);
-  text-transform: none;
-  letter-spacing: 0;
-}
-
-.dtz-kicker svg {
-  width: 1rem;
-  height: 1rem;
-}
-
 .dtz-hero h1,
 .dtz-section h2,
 .dtz-band h2,
 .dtz-contact h2 {
   margin: 0;
   color: var(--dtz-fg);
-  font-weight: 870;
-  line-height: 1.02;
-  letter-spacing: 0;
+  font-family: var(--font-serif);
+  font-weight: 620;
+  line-height: 1.06;
+  letter-spacing: -0.01em;
 }
 
 .dtz-hero h1 {
@@ -918,14 +901,6 @@ body {
 .dtz-card:hover,
 .dtz-nav-cta:hover {
   transform: translateY(-1px);
-}
-
-.dtz-hero-visual {
-  display: grid;
-  grid-template-columns: minmax(0, 0.82fr) minmax(220px, 0.6fr);
-  gap: 1rem;
-  align-items: stretch;
-  min-height: 0;
 }
 
 .dtz-workbench-frame {
@@ -1383,10 +1358,6 @@ body {
     grid-template-columns: 1fr;
   }
 
-  .dtz-hero-visual {
-    grid-template-columns: 1fr;
-  }
-
   .dtz-logo-tile,
   .dtz-stack-card {
     width: 100%;
@@ -1536,53 +1507,100 @@ body {
   }
 }
 
-/* 2026 personal portfolio overhaul */
-.dtz-overhaul-hero {
-  grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
-  gap: 3rem;
-  padding-block: 1.65rem 1.85rem;
+/* Warm Operator command-center hero */
+.dtz-command-hero {
+  display: block;
+  padding-block: clamp(3.2rem, 9vw, 6.5rem);
 }
 
-.dtz-overhaul-hero .dtz-hero-copy {
+.dtz-command-hero .dtz-hero-copy {
   min-width: 0;
 }
 
-.dtz-overhaul-hero .dtz-kicker {
-  max-width: max-content;
+.dtz-eyebrow {
+  margin: 0 0 1.4rem;
+  color: var(--dtz-accent);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
-.dtz-overhaul-hero h1 {
-  max-width: 18ch;
-  font-size: 2.95rem;
+.dtz-command-hero h1 {
+  max-width: 16ch;
+  font-size: clamp(2.5rem, 6.5vw, 4.35rem);
 }
 
-.dtz-overhaul-hero .dtz-lede {
-  font-size: 1.08rem;
-  line-height: 1.56;
+.dtz-command-hero .dtz-lede {
+  max-width: 56ch;
+  font-size: 1.16rem;
+  line-height: 1.6;
 }
 
-.dtz-overhaul-hero .dtz-hero-actions {
-  margin-top: 1.35rem;
+.dtz-command-hero .dtz-hero-actions {
+  margin-top: 1.6rem;
 }
 
-.dtz-hero-badges {
+.dtz-status-strip {
+  display: grid;
+  gap: 0.55rem;
+  max-width: 640px;
+  margin-top: 2.4rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid var(--dtz-border);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+.dtz-status-strip p {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.55rem;
-  margin: 1.25rem 0 0;
-  padding: 0;
-  list-style: none;
+  align-items: baseline;
+  gap: 0.3rem 0.6rem;
+  margin: 0;
+  color: var(--dtz-subtle);
 }
 
-.dtz-hero-badges li {
-  min-height: 34px;
-  padding: 0.42rem 0.62rem;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--dtz-panel) 88%, transparent);
-  color: var(--dtz-subtle);
-  font-size: 0.86rem;
-  font-weight: 780;
+.dtz-status-strip strong {
+  flex: 0 0 auto;
+  color: var(--dtz-accent);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.dtz-status-strip a {
+  color: var(--dtz-muted);
+  text-decoration-color: var(--dtz-accent-2);
+  text-underline-offset: 3px;
+}
+
+.dtz-status-dot {
+  flex: 0 0 auto;
+  align-self: center;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--dtz-accent);
+  animation: dtz-status-pulse 3.2s ease-in-out infinite;
+}
+
+@keyframes dtz-status-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dtz-status-dot {
+    animation: none;
+  }
 }
 
 .dtz-signal-list {
@@ -1614,278 +1632,6 @@ body {
   height: 1rem;
   flex: 0 0 auto;
   color: var(--dtz-accent);
-}
-
-.dtz-overhaul-visual {
-  position: relative;
-  display: block;
-  min-height: 415px;
-  isolation: isolate;
-}
-
-.dtz-showcase-stage {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto auto auto;
-  gap: 0.85rem;
-  min-height: 0;
-  overflow: hidden;
-  padding: 0.85rem;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--dtz-accent-soft) 52%, transparent), transparent 38%),
-    linear-gradient(225deg, color-mix(in srgb, var(--dtz-accent-2) 18%, transparent), transparent 42%),
-    var(--dtz-panel);
-  box-shadow: var(--dtz-shadow);
-}
-
-.dtz-showcase-stage::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image:
-    linear-gradient(color-mix(in srgb, var(--dtz-border) 20%, transparent) 1px, transparent 1px),
-    linear-gradient(90deg, color-mix(in srgb, var(--dtz-border) 16%, transparent) 1px, transparent 1px);
-  background-size: 42px 42px;
-  opacity: 0.22;
-}
-
-.dtz-stage-topline,
-.dtz-stage-grid,
-.dtz-stage-checks {
-  position: relative;
-  z-index: 1;
-}
-
-.dtz-stage-topline {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  color: var(--dtz-muted);
-  font-size: 0.84rem;
-  font-weight: 780;
-}
-
-.dtz-stage-topline span {
-  color: var(--dtz-accent);
-  font-size: 0.76rem;
-  font-weight: 850;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.dtz-stage-topline a,
-.dtz-proof-surface-copy a {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.38rem;
-  color: var(--dtz-accent);
-  font-weight: 850;
-  text-decoration: none;
-}
-
-.dtz-stage-topline svg,
-.dtz-proof-surface-copy svg {
-  width: 0.95rem;
-  height: 0.95rem;
-}
-
-.dtz-stage-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.25fr) minmax(210px, 0.72fr);
-  gap: 0.85rem;
-  min-height: 300px;
-}
-
-.dtz-live-preview,
-.dtz-mini-preview {
-  overflow: hidden;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  background: var(--dtz-panel-dark);
-  color: inherit;
-  text-decoration: none;
-  transition:
-    transform 180ms ease,
-    border-color 180ms ease,
-    filter 180ms ease;
-}
-
-.dtz-live-preview:hover,
-.dtz-mini-preview:hover,
-.dtz-proof-surface:hover {
-  transform: translateY(-3px);
-  border-color: color-mix(in srgb, var(--dtz-accent) 70%, var(--dtz-border));
-}
-
-.dtz-live-preview {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
-  min-height: 300px;
-}
-
-.dtz-browser-bar {
-  display: grid;
-  grid-template-columns: repeat(3, 0.54rem) minmax(0, 1fr);
-  gap: 0.38rem;
-  align-items: center;
-  min-height: 34px;
-  padding: 0 0.72rem;
-  border-bottom: 1px solid color-mix(in srgb, var(--dtz-border) 70%, transparent);
-  background: color-mix(in srgb, var(--dtz-panel-dark) 84%, var(--dtz-panel));
-}
-
-.dtz-browser-bar i {
-  width: 0.54rem;
-  height: 0.54rem;
-  border-radius: 999px;
-  background: var(--dtz-accent-2);
-}
-
-.dtz-browser-bar i:nth-child(2) {
-  background: var(--dtz-accent-3);
-}
-
-.dtz-browser-bar i:nth-child(3) {
-  background: var(--dtz-accent);
-}
-
-.dtz-browser-bar strong {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--dtz-subtle);
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  font-weight: 760;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.dtz-live-preview img,
-.dtz-mini-preview img,
-.dtz-proof-surface-media img {
-  width: 100% !important;
-  height: 100% !important;
-  object-fit: cover;
-  transition:
-    transform 260ms ease,
-    filter 260ms ease;
-}
-
-.dtz-live-preview:hover img,
-.dtz-mini-preview:hover img,
-.dtz-proof-surface:hover img {
-  filter: saturate(1.08) contrast(1.04);
-  transform: scale(1.025);
-}
-
-.dtz-stage-column {
-  display: grid;
-  gap: 0.85rem;
-  min-height: 0;
-}
-
-.dtz-mini-preview {
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-  min-height: 168px;
-}
-
-.dtz-mini-preview span {
-  display: grid;
-  gap: 0.18rem;
-  padding: 0.72rem;
-  border-top: 1px solid var(--dtz-border);
-  background: var(--dtz-panel);
-  color: var(--dtz-muted);
-  font-size: 0.84rem;
-  line-height: 1.35;
-}
-
-.dtz-mini-preview strong,
-.dtz-handoff-panel strong,
-.dtz-stage-check strong,
-.dtz-proof-surface h3 {
-  color: var(--dtz-fg);
-}
-
-.dtz-handoff-panel {
-  display: grid;
-  align-content: center;
-  gap: 0.45rem;
-  min-height: 120px;
-  padding: 0.85rem;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--dtz-accent-3) 16%, transparent), transparent 72%),
-    color-mix(in srgb, var(--dtz-panel) 92%, transparent);
-}
-
-.dtz-handoff-panel span,
-.dtz-proof-surface-copy span {
-  color: var(--dtz-accent);
-  font-size: 0.74rem;
-  font-weight: 850;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.dtz-handoff-panel p {
-  margin: 0;
-  color: var(--dtz-muted);
-  line-height: 1.45;
-}
-
-.dtz-stage-checks {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.55rem;
-}
-
-.dtz-stage-check {
-  display: grid;
-  grid-template-columns: 32px minmax(0, 1fr);
-  gap: 0.55rem;
-  align-items: center;
-  min-height: 56px;
-  padding: 0.55rem;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--dtz-panel) 88%, transparent);
-}
-
-.dtz-stage-check > span {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  background: var(--dtz-accent);
-  color: var(--dtz-on-accent);
-}
-
-.dtz-stage-check svg {
-  width: 1rem;
-  height: 1rem;
-}
-
-.dtz-stage-check strong,
-.dtz-stage-check small {
-  display: block;
-}
-
-.dtz-stage-check strong {
-  font-size: 0.86rem;
-  line-height: 1.1;
-}
-
-.dtz-stage-check small {
-  display: none;
 }
 
 .dtz-contact-card span {
@@ -2400,21 +2146,10 @@ body {
     grid-template-columns: 1fr;
   }
 
-  .dtz-overhaul-hero h1 {
-    font-size: 2.85rem;
-  }
-
-  .dtz-overhaul-visual {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1rem;
-    min-height: auto;
-  }
 }
 
 @media (max-width: 900px) {
-  .dtz-hero,
-  .dtz-overhaul-hero {
+  .dtz-hero {
     grid-template-columns: 1fr;
   }
 }
@@ -2454,87 +2189,12 @@ body {
 }
 
 @media (max-width: 560px) {
-  .dtz-overhaul-hero {
-    position: relative;
-    padding-block: 1.25rem 2rem;
-  }
-
-  .dtz-overhaul-hero .dtz-hero-copy {
-    position: relative;
-    z-index: 1;
-  }
-
-  .dtz-overhaul-hero h1 {
-    max-width: 13ch;
-    font-size: 2.32rem;
-  }
-
-  .dtz-hero-badges {
-    display: none;
+  .dtz-command-hero {
+    padding-block: 2.4rem 2.8rem;
   }
 
   .dtz-signal-list li {
     align-items: flex-start;
-  }
-
-  .dtz-overhaul-visual {
-    position: relative;
-    inset: auto;
-    z-index: 1;
-    display: block;
-    height: auto;
-    min-height: 0;
-    margin-top: 1.2rem;
-    padding: 0.55rem;
-    opacity: 1;
-    pointer-events: auto;
-    mask-image: none;
-  }
-
-  .dtz-stage-topline {
-    align-items: flex-start;
-  }
-
-  .dtz-stage-topline a {
-    white-space: nowrap;
-  }
-
-  .dtz-stage-grid {
-    grid-template-columns: 1fr;
-    min-height: 0;
-  }
-
-  .dtz-stage-column {
-    display: none;
-  }
-
-  .dtz-live-preview {
-    min-height: 220px;
-  }
-
-  .dtz-stage-checks {
-    grid-template-columns: repeat(5, minmax(104px, 1fr));
-    overflow-x: auto;
-    padding-bottom: 0.1rem;
-    scrollbar-width: none;
-  }
-
-  .dtz-stage-checks::-webkit-scrollbar {
-    display: none;
-  }
-
-  .dtz-stage-check {
-    grid-template-columns: 28px minmax(0, 1fr);
-    min-height: 50px;
-  }
-
-  .dtz-stage-check > span {
-    width: 28px;
-    height: 28px;
-  }
-
-  .dtz-stage-check strong {
-    font-size: 0.78rem;
   }
 
   .dtz-summary-band h2,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Fraunces, Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { socialProfileLinks } from "@/lib/contact-links";
 import "./globals.css";
@@ -12,6 +12,11 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   subsets: ["latin"],
   variable: "--font-geist-mono",
+});
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  variable: "--font-fraunces",
+  axes: ["opsz"],
 });
 
 const siteUrl = "https://davidtiz.com";
@@ -138,7 +143,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} ${fraunces.variable}`}>
       <body className="font-sans antialiased">
         <script
           type="application/ld+json"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useSyncExternalStore } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import { motion, useReducedMotion } from "framer-motion"
@@ -7,7 +8,7 @@ import { GithubIcon } from "@/components/icons/brand-icons"
 import { ProtectedWhatsAppLink } from "@/components/contact/protected-whatsapp-link"
 import { AIAssistant } from "@/components/ai-assistant"
 import { useSiteTheme } from "@/components/use-site-theme"
-import { contact, heroStatus, whatsappHref } from "@/data/content"
+import { contact, currentFocus, heroStatus, whatsappHref } from "@/data/content"
 import {
   ArrowUpRight,
   AtSign,
@@ -203,22 +204,32 @@ const stackGroups = [
   },
 ]
 
-const currentFocus = [
-  "Cleaner local-business websites with quote, order, or contact flows that do not feel overbuilt.",
-  "Repeatable AI-assisted delivery: research, implementation, review, browser QA, and a written handoff.",
-  "AI-security workflow habits, especially prompt injection, tool boundaries, and validation.",
-  "Better notes that preserve what worked, what failed, and what should happen in the next session.",
-]
-
 const contactGuardrails = [
   "Public links start with project context instead of a bare phone number.",
   "A future WhatsApp/n8n screener can label spam, ask one clarifying question, and keep human approval on replies.",
   "Direct calls should happen after context, not as the first public CTA bots can scrape.",
 ]
 
+const subscribeNoop = () => () => {}
+const getTrue = () => true
+const getFalse = () => false
+
 export default function HomePage() {
   const { theme, updateTheme } = useSiteTheme()
   const shouldReduceMotion = useReducedMotion()
+  // useSyncExternalStore reports false during SSR/hydration, true right after.
+  const hydrated = useSyncExternalStore(subscribeNoop, getTrue, getFalse)
+
+  // Motion props must be identical on server and client render (SSR bakes the
+  // initial styles into the HTML), so the reduced-motion branch may only kick
+  // in after hydration: it swaps the scroll-gated reveal for an instant one.
+  const instantReveal = Boolean(hydrated && shouldReduceMotion)
+  const reveal = (delay = 0) => ({
+    initial: { opacity: 0, y: 18 },
+    animate: instantReveal ? { opacity: 1, y: 0 } : undefined,
+    whileInView: { opacity: 1, y: 0 },
+    transition: instantReveal ? { duration: 0 } : { duration: 0.45, ease: "easeOut" as const, delay },
+  })
 
   return (
     <div className={`dtz-site dtz-${theme}`}>
@@ -346,12 +357,8 @@ export default function HomePage() {
             <motion.article
               className={index === 0 ? "dtz-proof-surface is-featured" : "dtz-proof-surface"}
               key={item.title}
-              initial={{ opacity: 0, y: 18 }}
-              whileInView={{ opacity: 1, y: 0 }}
+              {...reveal(index * 0.06)}
               viewport={{ once: true, amount: 0.25 }}
-              transition={
-                shouldReduceMotion ? { duration: 0 } : { duration: 0.45, ease: "easeOut", delay: index * 0.06 }
-              }
             >
               <Link className="dtz-proof-surface-media" href={item.href}>
                 <Image src={item.image} alt={item.alt} width={1440} height={index === 0 ? 1000 : 729} />
@@ -388,12 +395,8 @@ export default function HomePage() {
               <motion.article
                 className="dtz-setup-card"
                 key={item.title}
-                initial={{ opacity: 0, y: 18 }}
-                whileInView={{ opacity: 1, y: 0 }}
+                {...reveal(index * 0.05)}
                 viewport={{ once: true, amount: 0.25 }}
-                transition={
-                  shouldReduceMotion ? { duration: 0 } : { duration: 0.45, ease: "easeOut", delay: index * 0.05 }
-                }
               >
                 <span className="dtz-setup-icon">
                   <Icon aria-hidden="true" />
@@ -432,12 +435,8 @@ export default function HomePage() {
               <motion.article
                 className="dtz-work-card"
                 key={item.title}
-                initial={{ opacity: 0, y: 18 }}
-                whileInView={{ opacity: 1, y: 0 }}
+                {...reveal(index * 0.04)}
                 viewport={{ once: true, amount: 0.2 }}
-                transition={
-                  shouldReduceMotion ? { duration: 0 } : { duration: 0.45, ease: "easeOut", delay: index * 0.04 }
-                }
               >
                 <div className="dtz-work-media">
                   <Image src={item.image} alt="" width={900} height={640} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,11 +7,10 @@ import { GithubIcon } from "@/components/icons/brand-icons"
 import { ProtectedWhatsAppLink } from "@/components/contact/protected-whatsapp-link"
 import { AIAssistant } from "@/components/ai-assistant"
 import { useSiteTheme } from "@/components/use-site-theme"
-import { contact, whatsappHref } from "@/data/content"
+import { contact, heroStatus, whatsappHref } from "@/data/content"
 import {
   ArrowUpRight,
   AtSign,
-  BadgeCheck,
   BookOpen,
   CheckCircle2,
   ClipboardCheck,
@@ -19,7 +18,6 @@ import {
   Compass,
   FileText,
   Globe,
-  LockKeyhole,
   Mail,
   MessageCircle,
   Moon,
@@ -70,42 +68,6 @@ const proofSurfaces = [
     image: "/visuals/generated-workbench.webp",
     href: "#setup",
     alt: "Desk scene representing website setup, account handoff, and project notes.",
-  },
-]
-
-const heroHighlights = [
-  "Web systems",
-  "Automation workflows",
-  "AI-security checks",
-  "RAG & notes tools",
-  "Operating notes",
-]
-
-const launchFlow = [
-  {
-    title: "Website",
-    detail: "Clear pages, photos, services, forms",
-    icon: Globe,
-  },
-  {
-    title: "Domain",
-    detail: "A real address the business owns",
-    icon: BadgeCheck,
-  },
-  {
-    title: "Email",
-    detail: "Official inbox with familiar forwarding",
-    icon: AtSign,
-  },
-  {
-    title: "Social",
-    detail: "Facebook, Instagram, WhatsApp paths",
-    icon: Smartphone,
-  },
-  {
-    title: "Security",
-    detail: "2FA, recovery, and handoff notes",
-    icon: LockKeyhole,
   },
 ]
 
@@ -274,7 +236,7 @@ export default function HomePage() {
             />
             <span>
               <strong>David Ortiz</strong>
-              <small>builder/operator portfolio</small>
+              <small>Technical Systems Builder</small>
             </span>
           </Link>
 
@@ -315,113 +277,46 @@ export default function HomePage() {
         </nav>
       </header>
 
-      <section id="start" className="dtz-hero dtz-overhaul-hero" aria-labelledby="hero-title">
+      <section id="start" className="dtz-hero dtz-command-hero" aria-labelledby="hero-title">
         <motion.div
           className="dtz-hero-copy"
-          initial={shouldReduceMotion ? false : { opacity: 0, y: 16 }}
-          animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
-          transition={{ duration: 0.45, ease: "easeOut" }}
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.45, ease: "easeOut" }}
         >
-          <p className="dtz-kicker">
-            <Sparkles aria-hidden="true" />
-            Selected work, operating notes, and systems thinking
+          <p className="dtz-eyebrow">
+            Systems builder <span aria-hidden="true">{"//"}</span> AI orchestration · Security · Automation
           </p>
-          <h1 id="hero-title">I build practical web, automation, and AI-security systems.</h1>
+          <h1 id="hero-title">I build systems out of many AIs.</h1>
           <p className="dtz-lede">
-            I&apos;m David Ortiz. This is my personal proof hub: selected work, operating notes, and the decisions behind
-            the systems I build, test, and hand off.
+            I coordinate models, tools, and workflows into systems that hold up, and I study how they fail in public.
+            Not one technology, a working stack of them.
           </p>
-
-          <ul className="dtz-hero-badges" aria-label="What David can set up">
-            {heroHighlights.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
 
           <div className="dtz-hero-actions" aria-label="Primary actions">
             <a className="dtz-button primary" href="#work">
-              View selected work
+              See the systems
               <ArrowUpRight aria-hidden="true" />
             </a>
-            <a className="dtz-button secondary" href="#notes">
-              Read operating notes
-              <BookOpen aria-hidden="true" />
+            <a className="dtz-button secondary" href="#process">
+              How I work
+              <Compass aria-hidden="true" />
             </a>
           </div>
-        </motion.div>
 
-        <motion.div
-          className="dtz-hero-visual dtz-overhaul-visual dtz-showcase-stage"
-          aria-label="Website design and setup proof"
-          initial={shouldReduceMotion ? false : { opacity: 0, y: 18 }}
-          animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, ease: "easeOut", delay: 0.1 }}
-        >
-          <div className="dtz-stage-topline">
-            <span>Live screens, not just claims</span>
-            <Link href="/portfolio">
-              View portfolio
-              <ArrowUpRight aria-hidden="true" />
-            </Link>
-          </div>
-
-          <div className="dtz-stage-grid">
-            <Link className="dtz-live-preview" href="/portfolio">
-              <span className="dtz-browser-bar" aria-hidden="true">
-                <i />
-                <i />
-                <i />
-                <strong>davidtiz.com / portfolio</strong>
+          <div className="dtz-status-strip" aria-label="Current status">
+            <p>
+              <span className="dtz-status-dot" aria-hidden="true" />
+              <strong>Now</strong>
+              <span>{heroStatus.now}</span>
+            </p>
+            <p>
+              <strong>Last shipped</strong>
+              <span>
+                <Link href={heroStatus.lastShipped.href}>{heroStatus.lastShipped.label}</Link> ·{" "}
+                {heroStatus.lastShipped.date}
               </span>
-              <Image
-                src="/portfolio/hernandez/site-screenshot.png"
-                alt="Screenshot of a local business website portfolio example."
-                width={1440}
-                height={1000}
-                priority
-                loading="eager"
-                sizes="(max-width: 560px) calc(100vw - 44px), (max-width: 1020px) calc(100vw - 64px), 368px"
-              />
-            </Link>
-
-            <div className="dtz-stage-column">
-              <Link className="dtz-mini-preview" href="/portfolio">
-                <Image
-                  src="/portfolio/hernandez/site-trust-screenshot.png"
-                  alt="Screenshot of services and trust sections from a local business website."
-                  width={1440}
-                  height={729}
-                />
-                <span>
-                  <strong>Trust section</strong>
-                  Services, photos, contact path
-                </span>
-              </Link>
-
-              <div className="dtz-handoff-panel">
-                <span>Owner handoff</span>
-                <strong>Domain, inbox, social, recovery</strong>
-                <p>Set up around the tools the owner already uses.</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="dtz-stage-checks" aria-label="Setup path">
-            {launchFlow.map((item) => {
-              const Icon = item.icon
-
-              return (
-                <div className="dtz-stage-check" key={item.title}>
-                  <span aria-hidden="true">
-                    <Icon aria-hidden="true" />
-                  </span>
-                  <div>
-                    <strong>{item.title}</strong>
-                    <small>{item.detail}</small>
-                  </div>
-                </div>
-              )
-            })}
+            </p>
           </div>
         </motion.div>
       </section>
@@ -451,10 +346,12 @@ export default function HomePage() {
             <motion.article
               className={index === 0 ? "dtz-proof-surface is-featured" : "dtz-proof-surface"}
               key={item.title}
-              initial={shouldReduceMotion ? false : { opacity: 0, y: 18 }}
-              whileInView={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+              initial={{ opacity: 0, y: 18 }}
+              whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.25 }}
-              transition={{ duration: 0.45, ease: "easeOut", delay: index * 0.06 }}
+              transition={
+                shouldReduceMotion ? { duration: 0 } : { duration: 0.45, ease: "easeOut", delay: index * 0.06 }
+              }
             >
               <Link className="dtz-proof-surface-media" href={item.href}>
                 <Image src={item.image} alt={item.alt} width={1440} height={index === 0 ? 1000 : 729} />
@@ -491,10 +388,12 @@ export default function HomePage() {
               <motion.article
                 className="dtz-setup-card"
                 key={item.title}
-                initial={shouldReduceMotion ? false : { opacity: 0, y: 18 }}
-                whileInView={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+                initial={{ opacity: 0, y: 18 }}
+                whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.25 }}
-                transition={{ duration: 0.45, ease: "easeOut", delay: index * 0.05 }}
+                transition={
+                  shouldReduceMotion ? { duration: 0 } : { duration: 0.45, ease: "easeOut", delay: index * 0.05 }
+                }
               >
                 <span className="dtz-setup-icon">
                   <Icon aria-hidden="true" />
@@ -533,10 +432,12 @@ export default function HomePage() {
               <motion.article
                 className="dtz-work-card"
                 key={item.title}
-                initial={shouldReduceMotion ? false : { opacity: 0, y: 18 }}
-                whileInView={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+                initial={{ opacity: 0, y: 18 }}
+                whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.2 }}
-                transition={{ duration: 0.45, ease: "easeOut", delay: index * 0.04 }}
+                transition={
+                  shouldReduceMotion ? { duration: 0 } : { duration: 0.45, ease: "easeOut", delay: index * 0.04 }
+                }
               >
                 <div className="dtz-work-media">
                   <Image src={item.image} alt="" width={900} height={640} />

--- a/data/content.ts
+++ b/data/content.ts
@@ -190,7 +190,8 @@ export const processSteps = [
   },
 ]
 
-// Hero NOW/LAST SHIPPED strip. Keep both lines honest and current: update `now`
+// Hero NOW/LAST SHIPPED strip and the Notes section's current-focus list live
+// together so there is one honest update point: refresh `now` + `currentFocus`
 // when the working focus shifts, and `lastShipped` whenever something real ships.
 export const heroStatus = {
   now: "prompt-defense evals · multi-AI delivery workflows · learning in public",
@@ -200,6 +201,13 @@ export const heroStatus = {
     date: "Jun 2026",
   },
 }
+
+export const currentFocus = [
+  "Cleaner local-business websites with quote, order, or contact flows that do not feel overbuilt.",
+  "Repeatable AI-assisted delivery: research, implementation, review, browser QA, and a written handoff.",
+  "AI-security workflow habits, especially prompt injection, tool boundaries, and validation.",
+  "Better notes that preserve what worked, what failed, and what should happen in the next session.",
+]
 
 export const chatConfig = {
   title: 'PORTFOLIO GUIDE',

--- a/data/content.ts
+++ b/data/content.ts
@@ -190,6 +190,17 @@ export const processSteps = [
   },
 ]
 
+// Hero NOW/LAST SHIPPED strip. Keep both lines honest and current: update `now`
+// when the working focus shifts, and `lastShipped` whenever something real ships.
+export const heroStatus = {
+  now: "prompt-defense evals · multi-AI delivery workflows · learning in public",
+  lastShipped: {
+    label: "CTF writeups + proof cards",
+    href: "/writeups",
+    date: "Jun 2026",
+  },
+}
+
 export const chatConfig = {
   title: 'PORTFOLIO GUIDE',
   subtitle: 'Ask about the work, current experiments, or how he approaches projects',

--- a/docs/BRAND-WARM-OPERATOR-TOKENS-PROPOSAL.md
+++ b/docs/BRAND-WARM-OPERATOR-TOKENS-PROPOSAL.md
@@ -1,6 +1,6 @@
 # David Tiz brand: Warm Operator token set (proposal)
 
-Status: PROPOSAL, not yet applied to `app/globals.css`. Owner decision 2026-06-17 chose the "Warm Operator" direction to give davidtiz.com an identity distinct from Razon Lab (which owns dark + teal). This file is the drop-in replacement for the `--dtz-*` color tokens. Review, then apply to the `.dtz-site` light and dark blocks in `globals.css`.
+Status: APPLIED to `app/globals.css` (light and dark `.dtz-site` blocks). Owner decision 2026-06-17 chose the "Warm Operator" direction to give davidtiz.com an identity distinct from Razon Lab (which owns dark + teal). This file remains the reference for the `--dtz-*` color tokens.
 
 ## Why this palette
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What

Implements steps 3–4 of `docs/IDENTITY-AND-DESIGN-DIRECTION.md` (the Warm Operator redesign spec):

- **Serif display pairing** — Fraunces via `next/font` (`--font-serif`), applied to H1/section H2s. Geist Sans stays for body, Geist Mono for labels/metadata.
- **Command-center hero** — replaces the two-column screenshot stage with the spec's type-led hero: mono clay eyebrow (`SYSTEMS BUILDER // AI ORCHESTRATION · SECURITY · AUTOMATION`), serif headline ("I build systems out of many AIs.", spec section 8 option 1), spec subhead, and CTAs "See the systems" / "How I work".
- **NOW status strip** — mono strip with a slow pulse dot: `NOW: …` + `LAST SHIPPED: …`, content centralized in `data/content.ts` → `heroStatus`. Pulse respects `prefers-reduced-motion`.
- **Role label** — header brand line becomes "Technical Systems Builder" (adopted item from the spec's second-opinion reconciliation).
- **Dead CSS removal** — hero badges, kicker, and the whole stage/preview/handoff complex (~430 lines). Proof screenshots still live in the Proof-of-work section below the hero.

## Bug fix included

**Reduced-motion users saw a fully invisible page.** The `useReducedMotion` branches in `initial`/`animate`/`whileInView` made server HTML (inline `opacity: 0`) disagree with the client's first render (`initial={false}`); React couldn't reconcile and content stayed at opacity 0. Fixed by keeping motion props SSR-consistent and moving the reduced-motion branch into `transition` (instant, motionless reveal). Repros with Windows "animation effects" off / `prefers-reduced-motion: reduce`.

## Verification

- `npm run lint` / `npm test` (51/51) / `npm run build` — all green
- Browser-checked light + dark themes at desktop width: hero, all sections, contact, footer render correctly; Fraunces/Geist Mono confirmed via computed styles; hydration error gone (was reproducing on a reduced-motion machine)

## Out of scope (next slices per the spec)

- Home restructure to the 3-card "Selected systems" tier + From-the-lab + Writing sections
- ⌘K command palette, `/lab` log with tag filters, `/now` page
- Footer "operates High Encode Learning" line (needs brand-boundary allowed-link check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)