### PR TITLE
feat(content): reposition site around the AI-security identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 ## Project Overview
 
-Personal portfolio site for David Ortiz, built with Next.js 16 (App Router), React 19, and Tailwind CSS 4, deployed on Vercel. It is a single-page site that presents David as a builder/operator: selected work, how he works, his stack, current learning notes, and a clear contact path.
+Personal portfolio site for David Ortiz, built with Next.js 16 (App Router), React 19, and Tailwind CSS 4, deployed on Vercel. It presents one identity: an AI-security / offensive-evaluation engineer who also ships production software. Proof over description: verified competition results (Gray Swan Arena, NCL), live products (PromptDefenders), CTF writeups, and one shipped client build.
 
-It is NOT an "ecosystem router" or an agency site. Do not reframe it around HighEncode, CSBrainAI, Prompt Defenders, or a multi-site ecosystem. Outside projects may appear only as ordinary portfolio examples, never as the organizing structure.
+It is NOT an "ecosystem router" or an agency site. Do not reframe it around HighEncode, CSBrainAI, Prompt Defenders, or a multi-site ecosystem. Outside projects may appear only as ordinary portfolio examples, never as the organizing structure. SMB web-services sales/scoping belongs to highencodelearning.com; Hernandez Landscape appears here as exactly one secondary proof card/entry.
 
 **Production**: `davidtiz.com`
 **Vercel Project**: `david-ortiz-portfolio` (team: razs-projects-29d4f2e6)
@@ -54,11 +54,11 @@ components/
   ai-assistant.tsx  # Floating chat concierge on the homepage (calls /api/chat)
   contact/          # ProtectedWhatsAppLink — screened WhatsApp redirect (used by homepage + /contact)
   icons/            # brand-icons (used by homepage + /contact)
-data/content.ts     # Shared content + centralized contact (`contact`, `whatsappHref`)
+data/content.ts     # Shared content: heroChips, proofCards, chatConfig, centralized contact (`contact`, `whatsappHref`)
 lib/                # site-config, contact-links, meta-embedded-signup, abuse-store, utils
 public/visuals/     # Hero/workbench images and SVGs
-public/demo/        # Static Spanish local-business demos; hub served at /demo via rewrite,
-                    # linked from the homepage work card
+public/demo/        # Static Spanish local-business demos; hub served at /demo via rewrite
+                    # (no longer linked from the homepage)
 ```
 
 Tests live next to the code as `*.test.ts` (Vitest, node environment; `vitest.config.ts` maps `@/*` and stubs `server-only`).
@@ -70,15 +70,14 @@ Canonical boundary guidance lives in [`docs/ARCHITECTURE-BOUNDARIES.md`](docs/AR
 Short version: this app is intentionally small, so do not over-abstract; but do not let business/security rules drift further into framework files without characterization tests. For the WhatsApp redirect lane, preserve challenge validation, full challenge value integrity, replay blocking, sanitization, and redirect message behavior.
 
 ## Homepage sections (`components/home-page.tsx`)
-1. Header — brand + "Technical Systems Builder" role label, nav (Work / Lab / Process / Notes / Contact), light/dark toggle
-2. Hero — command-center hero per `docs/IDENTITY-AND-DESIGN-DIRECTION.md`: mono clay eyebrow, serif headline, CTAs (See the systems / How I work), NOW + LAST SHIPPED status strip (data in `data/content.ts` → `heroStatus`)
-3. Selected systems — 3 flagship proof cards in problem → built → proves format (`data/content.ts` → `flagshipSystems`), plus compact "other lanes" rows (`workLanes`)
-4. How I work — operating principles (process cards)
-5. From the lab — 3 newest writeups, read from `content/writeups` at build time by `app/page.tsx`
-6. Stack — tools he reaches for
-7. Notes / Current Focus — what he's working on now (`currentFocus`)
-8. Contact — WhatsApp-first (screened redirect), email, and GitHub
-9. Footer — WhatsApp · Email · GitHub
+1. Header — brand + "AI Security Engineer" role label, nav (Work / Process / Writeups / Contact), light/dark toggle
+2. Hero — one identity sentence ("I break AI systems and ship production software.") + 3 credential chips (`data/content.ts` → `heroChips`), CTAs (See the work / How I work)
+3. Selected proof — 4 proof cards, each one artifact + one result + one link (`data/content.ts` → `proofCards`), followed by a compact lab log: 3 newest writeups, read from `content/writeups` at build time by `app/page.tsx`
+4. How I work — 3 process steps
+5. Contact — one line + WhatsApp (screened redirect), email, and GitHub buttons
+6. Footer — WhatsApp · Email · GitHub · route links
+
+Copy rules for this page: every number must be checkable at the linked source; no em-dashes in rendered copy; no filler adjectives; keep body text under ~400 words. `/portfolio` is a proof index across the same categories (Hernandez is one entry, with scoping links to highencodelearning.com).
 
 ## Contact protection behavior
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,20 +2,20 @@ import { NextRequest, NextResponse } from "next/server"
 import { contact } from "@/data/content"
 import { incrementWindow } from "@/lib/abuse-store"
 
-const SYSTEM_PROMPT = `You are an AI assistant for David Ortiz's personal site (davidtiz.com). This site is a personal notebook and portfolio, not a sales page.
+const SYSTEM_PROMPT = `You are an AI assistant for David Ortiz's personal site (davidtiz.com). This site is a personal identity and portfolio surface, not a sales page.
 
 ## What davidtiz.com is for:
-- Personal notes, selected work, experiments, and learning-in-public
-- Explaining abstraction layers across browsers, apps, APIs, infrastructure, and business systems
-- Helping visitors understand what David builds and how he approaches projects
+- David's AI-security and offensive-evaluation work: authorized arena results (Gray Swan), NCL competition rankings, CTF writeups
+- His shipped software: PromptDefenders (prompt-injection scanner), RayBridge, and client web builds
+- Helping visitors understand the work and how to reach David
 
 ## What davidtiz.com is NOT for:
-- It is not the primary project sales page
+- It is not the SMB web-services sales page; formal scoping for local-business web work goes through highencodelearning.com
 - Do not present it like a course platform or education business
 - Do not route every question toward external services
 
 ## Guidance:
-- If someone asks what David is learning or building, answer from the perspective of experimentation, notes, and system design
+- Only state results that appear on the site; never invent rankings, breaks, clients, or certifications
 - Keep answers casual, concise, and useful
 - Default to 2-4 short sentences
 - Do not invent pricing or sales promises
@@ -197,11 +197,11 @@ function getFallbackResponse(userMessage: string): string {
   const lowerMessage = userMessage.toLowerCase()
 
   if (lowerMessage.includes("hire") || lowerMessage.includes("project") || lowerMessage.includes("service") || lowerMessage.includes("work")) {
-    return "This site is the personal portfolio and notes layer. If you want to start a scoped project, contact David directly at " + contact.email + "."
+    return "This site is David's personal identity surface. To start a scoped project, contact him directly at " + contact.email + "."
   }
 
   if (lowerMessage.includes("learn") || lowerMessage.includes("building") || lowerMessage.includes("studying")) {
-    return "Right now the focus is on abstraction layers, browser behavior, automation systems, AI tooling, and prompt safety. You can see current work in the selected work and notes sections."
+    return "Current focus: AI-security evaluation in authorized arenas, CTF competition, PromptDefenders, and production web builds. The work section and writeups have the details."
   }
 
   if (lowerMessage.includes("contact") || lowerMessage.includes("email") || lowerMessage.includes("whatsapp") || lowerMessage.includes("phone")) {
@@ -209,8 +209,8 @@ function getFallbackResponse(userMessage: string): string {
   }
 
   if (lowerMessage.includes("security") || lowerMessage.includes("audit")) {
-    return "Prompt safety, AI system behavior, and reliability testing are active topics across current work. He keeps notes on what worked, what failed, and what needs tightening."
+    return "AI security is the core lane: confirmed prompt-injection breaks in authorized arenas, an NCL Fall 2025 ranking, PromptDefenders, and CTF writeups, all linked from the work section."
   }
 
-  return "Ask about what David is learning, what he is building, or how he approaches project handoffs. If you're ready to start a conversation, use the Contact section."
+  return "Ask about the AI-security results, the shipped builds, or the writeups. If you're ready to start a conversation, use the Contact section."
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -136,8 +136,7 @@ export default function ContactPage() {
     },
     {
       heading: "Follow the work",
-      intro:
-        "Best if you want to inspect the actual code, experiments, and project follow-through.",
+      intro: "Best if you want the code, the streams, and the writeups behind the work.",
       links: followWorkLinks,
     },
   ]
@@ -152,8 +151,8 @@ export default function ContactPage() {
               A direct path to David, without making people guess
             </h1>
             <p className="mt-5 text-lg leading-relaxed" style={{ color: "var(--dtz-muted)" }}>
-              {personalSitePublicLabel} stays personal, experimental, and reflective. This page is the shareable contact hub:
-              the fastest confirmed ways to email, book time, start a freelance conversation, or move into a scoped business discussion.
+              {personalSitePublicLabel} is my personal site: AI-security work and shipped software. This page is the
+              shareable contact hub: the fastest confirmed ways to email, book time, or start a scoped conversation.
             </p>
             <div className="mt-6 flex flex-wrap gap-3">
               <span

--- a/app/globals.css
+++ b/app/globals.css
@@ -413,17 +413,9 @@ body {
   font-size: 3rem;
 }
 
-.dtz-lede,
 .dtz-section-heading p,
 .dtz-contact p {
   color: var(--dtz-muted);
-}
-
-.dtz-lede {
-  max-width: 60ch;
-  margin: 1.3rem 0 0;
-  font-size: 1.2rem;
-  line-height: 1.65;
 }
 
 .dtz-hero-actions,
@@ -500,46 +492,6 @@ body {
   font-weight: 850;
 }
 
-.dtz-notes-panel {
-  display: grid;
-  grid-template-columns: minmax(180px, 0.68fr) minmax(0, 1fr);
-  gap: 1rem;
-  align-items: stretch;
-}
-
-.dtz-notes-panel > img {
-  width: 100%;
-  height: 100% !important;
-  min-height: 100%;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  object-fit: cover;
-}
-
-.dtz-check-list {
-  display: grid;
-  gap: 0.9rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.dtz-check-list li {
-  display: grid;
-  grid-template-columns: 1.25rem 1fr;
-  gap: 0.75rem;
-  padding: 1rem;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  background: var(--dtz-panel);
-  color: var(--dtz-fg);
-  line-height: 1.55;
-}
-
-.dtz-check-list svg {
-  color: var(--dtz-accent);
-}
-
 .dtz-contact {
   margin-block: clamp(2rem, 6vw, 4rem);
 }
@@ -547,14 +499,6 @@ body {
 .dtz-contact-panel {
   display: grid;
   gap: 1rem;
-}
-
-.dtz-contact-panel img {
-  width: 100%;
-  height: 100% !important;
-  max-height: 230px;
-  border-radius: 8px;
-  object-fit: cover;
 }
 
 .dtz-contact-actions {
@@ -597,10 +541,6 @@ body {
     font-size: 2.45rem;
   }
 
-  .dtz-lede {
-    font-size: 1.13rem;
-  }
-
   .dtz-nav {
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.65rem;
@@ -633,14 +573,6 @@ body {
 
   .dtz-contact {
     grid-template-columns: 1fr;
-  }
-
-  .dtz-notes-panel {
-    grid-template-columns: 1fr;
-  }
-
-  .dtz-notes-panel > img {
-    max-height: 320px;
   }
 
   .dtz-footer {
@@ -797,146 +729,30 @@ body {
   font-size: clamp(2.5rem, 6.5vw, 4.35rem);
 }
 
-.dtz-command-hero .dtz-lede {
-  max-width: 56ch;
-  font-size: 1.16rem;
-  line-height: 1.6;
-}
-
 .dtz-command-hero .dtz-hero-actions {
   margin-top: 1.6rem;
 }
 
-.dtz-status-strip {
-  display: grid;
-  gap: 0.55rem;
-  max-width: 640px;
-  margin-top: 2.4rem;
-  padding-top: 1.1rem;
-  border-top: 1px solid var(--dtz-border);
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-  line-height: 1.55;
-}
-
-.dtz-status-strip p {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 0.3rem 0.6rem;
-  margin: 0;
-  color: var(--dtz-subtle);
-}
-
-.dtz-status-strip strong {
-  flex: 0 0 auto;
-  color: var(--dtz-accent);
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.dtz-status-strip a {
-  color: var(--dtz-muted);
-  text-decoration-color: var(--dtz-accent-2);
-  text-underline-offset: 3px;
-}
-
-.dtz-status-dot {
-  flex: 0 0 auto;
-  align-self: center;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--dtz-accent);
-  animation: dtz-status-pulse 3.2s ease-in-out infinite;
-}
-
-@keyframes dtz-status-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
-}
-
-/* Selected systems: problem -> built -> proves lines */
-.dtz-system-lines {
-  display: grid;
-  gap: 0.55rem;
-  margin: 0;
-}
-
-.dtz-system-lines > div {
-  display: grid;
-  grid-template-columns: 4.6rem minmax(0, 1fr);
-  gap: 0.65rem;
-}
-
-.dtz-system-lines dt {
-  padding-top: 0.18rem;
-  color: var(--dtz-accent);
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.dtz-system-lines dd {
-  margin: 0;
-  color: var(--dtz-muted);
-  font-size: 0.94rem;
-  line-height: 1.55;
+.dtz-command-hero .dtz-hero-chips {
+  margin: 2.2rem 0 0;
 }
 
 .dtz-proof-surface-copy .dtz-tag-list {
   margin: 0;
 }
 
-/* The rest of the bench: compact working lanes */
-.dtz-lane-list {
-  margin: 2.2rem 0 0;
-  padding: 0;
-  list-style: none;
+/* Lab log: latest writeups, tucked under the proof cards */
+.dtz-lab-strip {
+  margin-top: 2.6rem;
 }
 
-.dtz-lane-list li {
-  display: grid;
-  grid-template-columns: 7.5rem minmax(0, 1fr) auto;
-  gap: 0.5rem 1.1rem;
-  align-items: baseline;
-  padding: 0.95rem 0;
-  border-top: 1px solid var(--dtz-border);
+.dtz-lab-strip .dtz-section-label {
+  margin-bottom: 0.4rem;
 }
 
-.dtz-lane-label {
-  color: var(--dtz-accent);
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+.dtz-lab-strip .dtz-card-link {
+  margin-top: 1.2rem;
 }
-
-.dtz-lane-list strong {
-  display: block;
-  color: var(--dtz-fg);
-}
-
-.dtz-lane-list p {
-  margin: 0.2rem 0 0;
-  color: var(--dtz-muted);
-  line-height: 1.55;
-}
-
-.dtz-lane-list .dtz-card-link {
-  white-space: nowrap;
-}
-
-/* From the lab: latest writeups */
 .dtz-lab-list {
   margin: 0;
   padding: 0;
@@ -980,25 +796,9 @@ body {
 }
 
 @media (max-width: 760px) {
-  .dtz-lane-list li,
   .dtz-lab-list li {
     grid-template-columns: 1fr;
   }
-}
-
-.dtz-contact-card span {
-  color: var(--dtz-accent);
-  font-family: var(--font-mono);
-  font-size: 0.76rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.dtz-contact-card p {
-  margin: 0;
-  color: var(--dtz-muted);
-  line-height: 1.55;
 }
 
 .dtz-proof-section {
@@ -1007,7 +807,7 @@ body {
 
 .dtz-proof-surface-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
 }
 
@@ -1026,43 +826,10 @@ body {
     box-shadow 180ms ease;
 }
 
-.dtz-proof-surface.is-featured {
-  grid-row: span 2;
-  min-height: 620px;
-}
-
 .dtz-proof-surface:hover {
   transform: translateY(-3px);
   border-color: color-mix(in srgb, var(--dtz-accent) 70%, var(--dtz-border));
   box-shadow: 0 24px 64px color-mix(in srgb, var(--dtz-panel-dark) 20%, transparent);
-}
-
-.dtz-proof-surface-media {
-  display: block;
-  overflow: hidden;
-  aspect-ratio: 16 / 8.6;
-  border-bottom: 1px solid var(--dtz-border);
-  background: var(--dtz-panel-dark);
-}
-
-.dtz-proof-surface-media img {
-  width: 100% !important;
-  height: 100% !important;
-  object-fit: cover;
-  transition:
-    transform 260ms ease,
-    filter 260ms ease;
-}
-
-.dtz-proof-surface:hover img {
-  filter: saturate(1.08) contrast(1.04);
-  transform: scale(1.025);
-}
-
-.dtz-proof-surface.is-featured .dtz-proof-surface-media {
-  flex: 1 1 auto;
-  min-height: 420px;
-  aspect-ratio: auto;
 }
 
 .dtz-proof-surface-copy {
@@ -1106,8 +873,7 @@ body {
   height: 0.95rem;
 }
 
-.dtz-process-card h3,
-.dtz-stack-group h3 {
+.dtz-process-card h3 {
   margin: 0;
   color: var(--dtz-fg);
   line-height: 1.12;
@@ -1141,7 +907,7 @@ body {
 
 .dtz-process-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
 }
 
@@ -1179,106 +945,8 @@ body {
   font-size: 1.22rem;
 }
 
-.dtz-stack-section {
-  border-block: 1px solid var(--dtz-border);
-}
-
-.dtz-stack-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.dtz-stack-group {
-  display: grid;
-  gap: 0.85rem;
-  padding: 1rem;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--dtz-panel) 88%, transparent);
-}
-
-.dtz-stack-group h3 {
-  font-size: 1.12rem;
-}
-
-.dtz-stack-group ul {
-  display: grid;
-  gap: 0.48rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.dtz-stack-group li {
-  color: var(--dtz-muted);
-  line-height: 1.35;
-}
-
-.dtz-notes-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 0.72fr) minmax(420px, 1.08fr);
-  gap: 2rem;
-  align-items: start;
-}
-
-.dtz-notes-layout h2 {
-  max-width: 13ch;
-}
-
-.dtz-notes-layout > div:first-child p:last-child {
-  margin-top: 1rem;
-  color: var(--dtz-muted);
-  font-size: 1.08rem;
-  line-height: 1.7;
-}
-
-.dtz-notes-section .dtz-notes-panel {
-  grid-template-columns: 1fr;
-}
-
-.dtz-notes-section .dtz-notes-panel > img {
-  aspect-ratio: 2 / 1;
-  height: auto !important;
-  max-height: none;
-  object-fit: cover;
-}
-
 .dtz-overhaul-contact {
   grid-template-columns: minmax(0, 0.92fr) minmax(360px, 0.9fr);
-}
-
-.dtz-contact-card {
-  display: grid;
-  gap: 0.55rem;
-  padding: 1rem;
-  border: 1px solid var(--dtz-border);
-  border-radius: 8px;
-  background: var(--dtz-panel);
-}
-
-.dtz-contact-guard ul {
-  display: grid;
-  gap: 0.55rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.dtz-contact-guard li {
-  display: grid;
-  grid-template-columns: 1rem 1fr;
-  gap: 0.55rem;
-  color: var(--dtz-muted);
-  font-size: 0.95rem;
-  line-height: 1.45;
-}
-
-.dtz-contact-guard svg {
-  width: 1rem;
-  height: 1rem;
-  margin-top: 0.12rem;
-  color: var(--dtz-accent);
 }
 
 .dtz-overhaul-contact .dtz-contact-actions {
@@ -1292,25 +960,12 @@ body {
   text-align: left;
 }
 
-@media (max-width: 1180px) {
-
-  .dtz-process-grid,
-  .dtz-stack-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
 @media (max-width: 1020px) {
-  .dtz-notes-layout,
   .dtz-overhaul-contact {
     grid-template-columns: 1fr;
   }
 
-}
-
-@media (max-width: 760px) {
-  .dtz-process-grid,
-  .dtz-stack-grid {
+  .dtz-process-grid {
     grid-template-columns: 1fr;
   }
 }
@@ -1319,23 +974,10 @@ body {
   .dtz-proof-surface-grid {
     grid-template-columns: 1fr;
   }
-
-  .dtz-proof-surface.is-featured {
-    min-height: auto;
-  }
-
-  .dtz-proof-surface.is-featured .dtz-proof-surface-media {
-    min-height: 0;
-    aspect-ratio: 16 / 10;
-  }
 }
 
 @media (max-width: 560px) {
   .dtz-command-hero {
     padding-block: 2.4rem 2.8rem;
-  }
-
-  .dtz-notes-layout h2 {
-    max-width: 100%;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,23 +20,21 @@ const fraunces = Fraunces({
 });
 
 const siteUrl = "https://davidtiz.com";
-const siteTitle = "David Ortiz | Personal Portfolio";
+const siteTitle = "David Ortiz | AI Security Engineer";
 const siteDescription =
-  "Personal portfolio for David Ortiz: practical web systems, AI-assisted workflows, automation experiments, selected builds, and notes.";
+  "Personal site for David Ortiz: AI security and offensive evaluation work, competition rankings, and production software builds.";
 
 export const metadata: Metadata = {
   title: siteTitle,
   description: siteDescription,
   keywords: [
     "David Ortiz",
-    "personal portfolio",
-    "web systems",
-    "AI-assisted workflows",
-    "automation",
+    "AI security",
+    "prompt injection",
+    "offensive evaluation",
+    "National Cyber League",
+    "CTF writeups",
     "Next.js",
-    "local business websites",
-    "RAG experiments",
-    "prompt safety",
   ],
   applicationName: "David Ortiz Portfolio",
   creator: "David Ortiz",
@@ -54,7 +52,7 @@ export const metadata: Metadata = {
         url: "/visuals/david-og-card.png",
         width: 1200,
         height: 630,
-        alt: "David Ortiz, builder and operator portfolio",
+        alt: "David Ortiz, AI security and software portfolio",
       },
     ],
   },
@@ -115,7 +113,7 @@ const personJsonLd = {
   "@type": "Person",
   name: "David Ortiz",
   url: siteUrl,
-  jobTitle: "Web developer and AI automation builder",
+  jobTitle: "AI Security Engineer",
   description: siteDescription,
   email: "hello@davidtiz.com",
   image: `${siteUrl}/visuals/david-og-card.png`,
@@ -126,13 +124,13 @@ const personJsonLd = {
     addressCountry: "US",
   },
   knowsAbout: [
-    "Web development",
+    "AI security evaluation",
+    "Prompt injection",
+    "Log analysis",
+    "Network traffic analysis",
+    "Web application security",
     "Next.js",
-    "AI-assisted workflows",
-    "Automation",
-    "Prompt injection defense",
-    "Local business websites",
-    "RAG systems",
+    "Web development",
   ],
   sameAs: [...socialProfileLinks],
 };

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,18 +1,6 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
-import {
-  ArrowLeft,
-  ArrowRight,
-  CheckCircle2,
-  ExternalLink,
-  FileText,
-  Mail,
-  MapPin,
-  MousePointerClick,
-  Quote,
-  Star,
-} from "lucide-react";
+import { ArrowLeft, ArrowUpRight, Mail } from "lucide-react";
 
 import { businessSiteUrl } from "@/lib/site-config";
 import { contact } from "@/data/content";
@@ -21,14 +9,14 @@ import { ThemeShell } from "@/components/theme-shell";
 export const metadata: Metadata = {
   title: "Portfolio | David Ortiz",
   description:
-    "Portfolio for David Ortiz, including the Hernandez Landscape website, sourced customer review links, and local-business quote flow.",
+    "Proof index for David Ortiz: Gray Swan Arena prompt-injection results, NCL Fall 2025 ranking, PromptDefenders, CTF writeups, RayBridge, and a shipped client site.",
   alternates: {
     canonical: "/portfolio",
   },
   openGraph: {
     title: "Portfolio | David Ortiz",
     description:
-      "Portfolio for David Ortiz, including the Hernandez Landscape website, sourced customer review links, and local-business quote flow.",
+      "Proof index for David Ortiz: Gray Swan Arena prompt-injection results, NCL Fall 2025 ranking, PromptDefenders, CTF writeups, RayBridge, and a shipped client site.",
     url: "/portfolio",
     type: "website",
   },
@@ -36,100 +24,85 @@ export const metadata: Metadata = {
     card: "summary",
     title: "Portfolio | David Ortiz",
     description:
-      "Portfolio for David Ortiz, including the Hernandez Landscape website, sourced customer review links, and local-business quote flow.",
+      "Proof index for David Ortiz: Gray Swan Arena prompt-injection results, NCL Fall 2025 ranking, PromptDefenders, CTF writeups, RayBridge, and a shipped client site.",
   },
 };
 
-const highlights = [
-  "Bilingual English and Spanish paths",
-  "Instant estimator that pre-fills the full quote request (address, owner confirmation, callback time, service, and estimate range) into the lead form",
-  "Service pages for lawn care, tree service, landscaping, and snow removal",
-  "Project gallery, sourced public review, and local service-area content",
-];
+type ProofEntry = {
+  category: string;
+  title: string;
+  result: string;
+  links: { href: string; label: string; external?: boolean }[];
+};
 
-const packageExamples = [
+const proofEntries: ProofEntry[] = [
   {
-    title: "Website launch",
-    description:
-      "Mobile-first service site with calls, quote forms, gallery sections, and local SEO basics.",
+    category: "AI security",
+    title: "Gray Swan Arena: frontier-model breaks",
+    result:
+      "42 unique breaks across authorized arenas, including 21 in the Indirect Prompt Injection Q2 2026 wave (76th of 232) and waves for agent red-teaming, safeguards, and machine-in-the-middle. Winner's Circle member. Independent research, not client pentests.",
+    links: [
+      {
+        href: "https://app.grayswan.ai/arena/user/67d3110be637c128d0cca612",
+        label: "Public arena profile",
+        external: true,
+      },
+    ],
   },
   {
-    title: "Local growth",
-    description:
-      "Website plus Google Maps, social proof, follow-up flow, and lead generation setup.",
+    category: "CTF",
+    title: "National Cyber League, Fall 2025",
+    result:
+      "24th of 620 overall in the Experienced bracket, 97th percentile. 1st of 620 in Log Analysis, 3rd in Network Traffic Analysis, 7th in Web Application Exploitation.",
+    links: [
+      {
+        href: "https://cyberskyline.com/report/BC2QQYBBP3L3",
+        label: "Official score report",
+        external: true,
+      },
+    ],
   },
   {
-    title: "Ongoing care",
-    description:
-      "Monthly updates, seasonal service changes, tracking, and campaign support.",
-  },
-];
-
-const referenceLinks = [
-  {
-    title: "Live landscaping website",
-    description:
-      "The Hernandez site lets visitors inspect the finished landscaping example in its live form.",
-    href: "https://hernandezlandscapeservices.com",
-    icon: MapPin,
+    category: "Product",
+    title: "PromptDefenders",
+    result:
+      "A live prompt-injection scanner that scores text against a versioned rule pack: instruction override, data exfiltration, and tool misuse, flagged before a model sees them.",
+    links: [
+      { href: "https://prompt-defenders.vercel.app", label: "Run the scanner", external: true },
+      { href: "https://github.com/RazonIn4K/prompt-defenders", label: "Source", external: true },
+    ],
   },
   {
-    title: "Services and work page",
-    description:
-      "A broader work page with supporting local-business examples and delivery context.",
-    href: `${businessSiteUrl}/work`,
-    icon: ExternalLink,
+    category: "Writeups",
+    title: "CTF technique writeups",
+    result:
+      "7 dated writeups across log analysis, forensics, binary exploitation, and web, with flags and live details redacted.",
+    links: [{ href: "/writeups", label: "Read the writeups" }],
   },
   {
-    title: "Hernandez case note",
-    description:
-      "Detailed breakdown of bilingual copy, service structure, trust signals, and quote capture.",
-    href: `${businessSiteUrl}/projects/hernandez-landscape-local-business-site`,
-    icon: FileText,
-  },
-];
-
-const stackSignals = [
-  "HTML, CSS, and JavaScript",
-  "Vanilla bilingual i18n",
-  "Web3Forms lead capture",
-  "Estimator and service-to-quote prefill",
-  "Responsive service-card layout",
-  "Local SEO and service-area copy",
-];
-
-const liveProofUpdates = [
-  {
-    title: "Sourced review links",
-    description:
-      "The Hernandez trust section now references a public review instead of generic placeholder testimonials.",
-    icon: Star,
+    category: "Open source",
+    title: "RayBridge",
+    result: "An MCP server that bridges Raycast extensions to any MCP-compatible client.",
+    links: [
+      { href: "https://github.com/RazonIn4K/raybridge", label: "Repository", external: true },
+      { href: contact.github, label: "All repos", external: true },
+    ],
   },
   {
-    title: "Estimate-to-form handoff",
-    description:
-      "After the instant estimate, a Send My Estimate Request button now pre-fills the quote form with the address, owner confirmation, callback time, service, and estimate summary, in English and Spanish.",
-    icon: MousePointerClick,
-  },
-  {
-    title: "Aligned reference links",
-    description:
-      "This page, the services page, and the case note now point to the same current live example.",
-    icon: Quote,
+    category: "Client build",
+    title: "Hernandez Landscape",
+    result:
+      "A bilingual services site for a real landscaping business: quote flow, gallery, and local SEO. Live and owner-run. Similar web work scopes through highencodelearning.com.",
+    links: [
+      { href: "https://hernandezlandscapeservices.com", label: "Live site", external: true },
+      { href: `${businessSiteUrl}/contact`, label: "Scope a build", external: true },
+    ],
   },
 ];
 
 const panelStyle = {
   borderColor: "var(--dtz-border)",
   background: "var(--dtz-panel)",
-} as const;
-const panelDeepStyle = {
-  borderColor: "var(--dtz-border)",
-  background: "var(--dtz-panel-2)",
-} as const;
-const iconChipStyle = {
-  background: "var(--dtz-accent-soft)",
-  color: "var(--dtz-accent)",
 } as const;
 const mutedText = { color: "var(--dtz-muted)" } as const;
 const primaryCtaStyle = {
@@ -141,7 +114,7 @@ export default function PortfolioPage() {
   return (
     <ThemeShell>
       <main className="min-h-screen px-6 py-12">
-        <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-6xl">
           <nav className="flex flex-wrap items-center justify-between gap-4">
             <Link
               href="/"
@@ -161,274 +134,54 @@ export default function PortfolioPage() {
             </a>
           </nav>
 
-          <section className="grid gap-12 py-16 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
-            <div>
-              <p className="dtz-section-label">Portfolio</p>
-              <h1 className="mt-5 text-4xl font-bold leading-tight md:text-6xl">
-                Real local-business work, starting with Hernandez Landscape
-              </h1>
-              <p className="mt-6 max-w-2xl text-lg leading-relaxed" style={mutedText}>
-                This page gives visitors a direct reference point. Hernandez
-                Landscape & Tree Service is a live landscaping website with
-                bilingual content, service positioning, project photos, and a
-                quote flow built around local customer calls, sourced trust
-                signals, and estimate requests that carry straight into the
-                contact form.
-              </p>
-              <div className="mt-8 flex flex-col gap-4 sm:flex-row">
-                <a
-                  href="https://hernandezlandscapeservices.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center gap-2 rounded-2xl px-6 py-3 font-semibold transition-transform hover:scale-[1.01]"
-                  style={primaryCtaStyle}
-                >
-                  View live Hernandez site
-                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
-                </a>
-                <a
-                  href={`${businessSiteUrl}/projects/hernandez-landscape-local-business-site`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center gap-2 rounded-2xl border px-6 py-3 font-semibold transition-colors"
-                  style={{ borderColor: "var(--dtz-border)", color: "var(--dtz-muted)" }}
-                >
-                  Read case note
-                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                </a>
-              </div>
-            </div>
+          <header className="max-w-3xl py-14">
+            <p className="dtz-section-label">Portfolio</p>
+            <h1 className="mt-5 text-4xl font-bold leading-tight md:text-6xl">
+              Proof index
+            </h1>
+            <p className="mt-6 text-lg leading-relaxed" style={mutedText}>
+              Security results, live products, and shipped builds. Every entry
+              links to its source.
+            </p>
+          </header>
 
-            <div
-              className="rounded-3xl border p-4"
-              style={{ ...panelStyle, boxShadow: "var(--dtz-shadow)" }}
-            >
-              <Image
-                src="/portfolio/hernandez/site-screenshot.png"
-                alt="Screenshot of the Hernandez Landscape website"
-                width={1440}
-                height={1000}
-                className="h-auto w-full rounded-2xl border"
-                style={{ borderColor: "var(--dtz-border)" }}
-                priority
-              />
-            </div>
-          </section>
-
-          <section className="grid gap-4 pb-10 md:grid-cols-3">
-            {liveProofUpdates.map((item) => {
-              const Icon = item.icon;
-
-              return (
-                <article key={item.title} className="rounded-3xl border p-6" style={panelStyle}>
-                  <span
-                    className="flex h-11 w-11 items-center justify-center rounded-2xl"
-                    style={iconChipStyle}
-                  >
-                    <Icon className="h-5 w-5" aria-hidden="true" />
-                  </span>
-                  <h2 className="mt-5 text-lg font-semibold">{item.title}</h2>
-                  <p className="mt-3 text-sm leading-relaxed" style={mutedText}>
-                    {item.description}
-                  </p>
-                </article>
-              );
-            })}
-          </section>
-
-          <section className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
-            <div className="rounded-3xl border p-6" style={panelStyle}>
-              <p className="dtz-section-label">What the example shows</p>
-              <div className="mt-6 space-y-4">
-                {highlights.map((highlight) => (
-                  <div key={highlight} className="flex gap-3">
-                    <span
-                      className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full"
-                      style={{ background: "var(--dtz-accent)" }}
-                    />
-                    <p className="text-sm leading-relaxed" style={mutedText}>
-                      {highlight}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <div className="grid gap-6 md:grid-cols-3">
-              {packageExamples.map((item) => (
-                <article key={item.title} className="rounded-3xl border p-6" style={panelStyle}>
-                  <h2 className="text-lg font-semibold">{item.title}</h2>
-                  <p className="mt-3 text-sm leading-relaxed" style={mutedText}>
-                    {item.description}
-                  </p>
-                </article>
-              ))}
-            </div>
-          </section>
-
-          <section className="grid gap-6 py-16 lg:grid-cols-[1.05fr_0.95fr]">
-            <div className="rounded-3xl border p-6 md:p-8" style={panelStyle}>
-              <p className="dtz-section-label">Reference links</p>
-              <h2 className="mt-4 text-2xl font-bold md:text-3xl">
-                Each link answers a different question about the work.
-              </h2>
-              <div className="mt-6 grid gap-4">
-                {referenceLinks.map((item) => {
-                  const Icon = item.icon;
-
-                  return (
-                    <a
-                      key={item.href}
-                      href={item.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group flex items-start gap-4 rounded-2xl border p-4 transition-colors"
-                      style={panelDeepStyle}
-                    >
-                      <span
-                        className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl"
-                        style={iconChipStyle}
+          <section className="grid gap-4 pb-16 md:grid-cols-2" aria-label="Proof entries">
+            {proofEntries.map((entry) => (
+              <article key={entry.title} className="rounded-3xl border p-6" style={panelStyle}>
+                <p className="dtz-section-label">{entry.category}</p>
+                <h2 className="mt-3 text-xl font-semibold">{entry.title}</h2>
+                <p className="mt-3 text-sm leading-relaxed" style={mutedText}>
+                  {entry.result}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-4">
+                  {entry.links.map((link) =>
+                    link.external ? (
+                      <a
+                        key={link.href}
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-sm font-semibold"
+                        style={{ color: "var(--dtz-accent)" }}
                       >
-                        <Icon className="h-5 w-5" aria-hidden="true" />
-                      </span>
-                      <span>
-                        <span className="flex items-center gap-2 text-sm font-semibold">
-                          {item.title}
-                          <ArrowRight
-                            className="h-4 w-4 transition-transform group-hover:translate-x-0.5"
-                            style={{ color: "var(--dtz-subtle)" }}
-                            aria-hidden="true"
-                          />
-                        </span>
-                        <span className="mt-1 block text-sm leading-relaxed" style={mutedText}>
-                          {item.description}
-                        </span>
-                      </span>
-                    </a>
-                  );
-                })}
-              </div>
-            </div>
-
-            <div className="rounded-3xl border p-6 md:p-8" style={panelStyle}>
-              <p className="dtz-section-label">Build signals</p>
-              <h2 className="mt-4 text-2xl font-bold md:text-3xl">
-                Concrete stack, not placeholder labels.
-              </h2>
-              <p className="mt-4 text-sm leading-relaxed" style={mutedText}>
-                Clients do not need the whole implementation story, but they
-                should see that the site was built with real production pieces and
-                not just a static mockup.
-              </p>
-              <div className="mt-6 grid gap-3">
-                {stackSignals.map((signal) => (
-                  <div
-                    key={signal}
-                    className="flex items-center gap-3 rounded-2xl border px-4 py-3"
-                    style={panelDeepStyle}
-                  >
-                    <CheckCircle2
-                      className="h-4 w-4 shrink-0"
-                      style={{ color: "var(--dtz-accent)" }}
-                      aria-hidden="true"
-                    />
-                    <span className="text-sm" style={mutedText}>
-                      {signal}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </section>
-
-          <section className="grid gap-6 py-16 lg:grid-cols-3">
-            <div className="overflow-hidden rounded-3xl border" style={panelStyle}>
-              <Image
-                src="/portfolio/hernandez/landscape-work-hero.jpeg"
-                alt="Landscaping project photo used for Hernandez Landscape"
-                width={1600}
-                height={1000}
-                loading="eager"
-                className="aspect-[16/10] w-full object-cover"
-              />
-              <div className="p-6">
-                <h2 className="text-lg font-semibold">Real project imagery</h2>
-                <p className="mt-2 text-sm leading-relaxed" style={mutedText}>
-                  The site uses real work photos instead of generic stock imagery,
-                  so prospects can inspect the type of landscaping work the
-                  business actually performs.
-                </p>
-              </div>
-            </div>
-
-            <div className="overflow-hidden rounded-3xl border" style={panelStyle}>
-              <Image
-                src="/portfolio/hernandez/site-trust-screenshot.png"
-                alt="Sourced customer feedback section from the Hernandez Landscape website"
-                width={1440}
-                height={729}
-                loading="eager"
-                className="aspect-[16/10] w-full object-cover object-top"
-              />
-              <div className="p-6">
-                <h2 className="text-lg font-semibold">Sourced trust section</h2>
-                <p className="mt-2 text-sm leading-relaxed" style={mutedText}>
-                  The trust section now points to a public review source, keeping
-                  the sales page credible and easy to defend.
-                </p>
-              </div>
-            </div>
-
-            <div className="overflow-hidden rounded-3xl border" style={panelStyle}>
-              <Image
-                src="/portfolio/hernandez/sergio-landscaping-marketing-clean.png"
-                alt="Clean marketing visual for landscaping and snow removal outreach"
-                width={1080}
-                height={1080}
-                loading="eager"
-                className="aspect-square w-full object-cover"
-              />
-              <div className="p-6">
-                <h2 className="text-lg font-semibold">
-                  Clean outreach collateral
-                </h2>
-                <p className="mt-2 text-sm leading-relaxed" style={mutedText}>
-                  The share image is built with clean rendered text, avoiding
-                  distorted lettering when it is sent through Messenger or social
-                  DMs.
-                </p>
-              </div>
-            </div>
-          </section>
-
-          <section className="pb-12">
-            <div
-              className="rounded-3xl border p-6 md:p-8"
-              style={{ borderColor: "var(--dtz-border)", background: "var(--dtz-accent-soft)" }}
-            >
-              <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
-                <div>
-                  <p className="dtz-section-label">Next step</p>
-                  <h2 className="mt-3 text-2xl font-bold">
-                    Want something like this for your local business?
-                  </h2>
-                  <p className="mt-2 max-w-2xl text-sm leading-relaxed" style={mutedText}>
-                    Use the services-facing contact flow for formal scoping,
-                    project questions, and local-business delivery.
-                  </p>
+                        {link.label}
+                        <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                      </a>
+                    ) : (
+                      <Link
+                        key={link.href}
+                        href={link.href}
+                        className="inline-flex items-center gap-1.5 text-sm font-semibold"
+                        style={{ color: "var(--dtz-accent)" }}
+                      >
+                        {link.label}
+                        <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                      </Link>
+                    ),
+                  )}
                 </div>
-                <a
-                  href={`${businessSiteUrl}/contact`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center gap-2 rounded-2xl px-6 py-3 font-semibold transition-transform hover:scale-[1.01]"
-                  style={primaryCtaStyle}
-                >
-                  Start a project
-                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                </a>
-              </div>
-            </div>
+              </article>
+            ))}
           </section>
         </div>
       </main>

--- a/components/home-page.tsx
+++ b/components/home-page.tsx
@@ -8,76 +8,42 @@ import { GithubIcon } from "@/components/icons/brand-icons"
 import { ProtectedWhatsAppLink } from "@/components/contact/protected-whatsapp-link"
 import { AIAssistant } from "@/components/ai-assistant"
 import { useSiteTheme } from "@/components/use-site-theme"
-import { contact, currentFocus, flagshipSystems, heroStatus, whatsappHref, workLanes } from "@/data/content"
+import { contact, heroChips, proofCards, whatsappHref } from "@/data/content"
 import type { WriteupMeta } from "@/lib/writeups"
 import {
   ArrowUpRight,
-  CheckCircle2,
-  ClipboardCheck,
   Code2,
   Compass,
   FileText,
   Mail,
   MessageCircle,
   Moon,
-  ShieldCheck,
   Sun,
 } from "lucide-react"
 
 const navItems = [
   { label: "Work", href: "#work" },
-  { label: "Lab", href: "#lab" },
   { label: "Process", href: "#process" },
-  { label: "Notes", href: "#notes" },
+  { label: "Writeups", href: "/writeups" },
   { label: "Contact", href: "#contact" },
 ]
 
 const processSteps = [
   {
-    title: "Start With The Real Surface",
-    body: "I look at the current site, social page, domain, inbox, or workflow first so the work starts from the real situation.",
+    title: "Recon The Real Surface",
+    body: "Start from the actual model, repo, or live site, not a slide about it.",
     icon: Compass,
   },
   {
-    title: "Map The Useful Version",
-    body: "I separate what customers need to see, what the owner needs to control, and what should be kept simple.",
-    icon: ClipboardCheck,
-  },
-  {
-    title: "Build In Working Passes",
-    body: "I ship a working first version, then tighten the design, copy, forms, routes, contact paths, and edge cases.",
+    title: "Build And Break In Passes",
+    body: "Ship a working version, test it, attack it, tighten it.",
     icon: Code2,
   },
   {
-    title: "Verify And Hand Off",
-    body: "I run the checks that matter, document what changed, and leave the owner with a clear continuation path.",
+    title: "Write It Down",
+    body: "Dated writeups and handoff docs, with sensitive details redacted.",
     icon: FileText,
   },
-]
-
-const stackGroups = [
-  {
-    title: "Frontend",
-    items: ["Next.js", "React", "Tailwind CSS", "Accessible UI"],
-  },
-  {
-    title: "Deployment",
-    items: ["Vercel", "Netlify", "DNS setup", "Production QA"],
-  },
-  {
-    title: "Automation",
-    items: ["n8n", "APIs", "Shell scripts", "Operational notes"],
-  },
-  {
-    title: "AI Workflow",
-    items: ["Codex", "Claude Code", "Grok", "Perplexity", "Obsidian"],
-  },
-]
-
-const contactGuardrails = [
-  "Public links start with project context instead of a bare phone number.",
-  "A future WhatsApp/n8n screener can label spam, ask one clarifying question, and keep human approval on replies.",
-  "Direct calls should happen after context, not as the first public CTA bots can scrape.",
 ]
 
 const subscribeNoop = () => () => {}
@@ -117,7 +83,7 @@ export function HomePage({ labNotes }: { labNotes: WriteupMeta[] }) {
             />
             <span>
               <strong>David Ortiz</strong>
-              <small>Technical Systems Builder</small>
+              <small>AI Security Engineer</small>
             </span>
           </Link>
 
@@ -166,17 +132,13 @@ export function HomePage({ labNotes }: { labNotes: WriteupMeta[] }) {
           transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.45, ease: "easeOut" }}
         >
           <p className="dtz-eyebrow">
-            Systems builder <span aria-hidden="true">{"//"}</span> AI orchestration · Security · Automation
+            AI security <span aria-hidden="true">{"//"}</span> offensive evaluation · production software
           </p>
-          <h1 id="hero-title">I build systems out of many AIs.</h1>
-          <p className="dtz-lede">
-            I coordinate models, tools, and workflows into systems that hold up, and I study how they fail in public.
-            Not one technology, a working stack of them.
-          </p>
+          <h1 id="hero-title">I break AI systems and ship production software.</h1>
 
           <div className="dtz-hero-actions" aria-label="Primary actions">
             <a className="dtz-button primary" href="#work">
-              See the systems
+              See the work
               <ArrowUpRight aria-hidden="true" />
             </a>
             <a className="dtz-button secondary" href="#process">
@@ -185,56 +147,31 @@ export function HomePage({ labNotes }: { labNotes: WriteupMeta[] }) {
             </a>
           </div>
 
-          <div className="dtz-status-strip" aria-label="Current status">
-            <p>
-              <span className="dtz-status-dot" aria-hidden="true" />
-              <strong>Now</strong>
-              <span>{heroStatus.now}</span>
-            </p>
-            <p>
-              <strong>Last shipped</strong>
-              <span>
-                <Link href={heroStatus.lastShipped.href}>{heroStatus.lastShipped.label}</Link> ·{" "}
-                {heroStatus.lastShipped.date}
-              </span>
-            </p>
-          </div>
+          <ul className="dtz-tag-list dtz-hero-chips" aria-label="Credentials">
+            {heroChips.map((chip) => (
+              <li key={chip}>{chip}</li>
+            ))}
+          </ul>
         </motion.div>
       </section>
 
       <section id="work" className="dtz-section dtz-proof-section" aria-labelledby="work-title">
         <div className="dtz-section-heading">
-          <p className="dtz-section-label">Selected systems</p>
-          <h2 id="work-title">Three systems, each with proof.</h2>
-          <p>
-            The flagship builds, all in the same format: the problem, what I built, and what it proves. The rest of the
-            bench is below, and the working notes live in the lab.
-          </p>
+          <p className="dtz-section-label">Selected proof</p>
+          <h2 id="work-title">Break results, rankings, and live builds.</h2>
         </div>
 
         <div className="dtz-proof-surface-grid">
-          {flagshipSystems.map((item, index) => {
-            const media = (
-              <Image src={item.image} alt={item.alt} width={1440} height={index === 0 ? 1000 : 729} />
-            )
+          {proofCards.map((item, index) => {
             const linkProps = item.external ? { target: "_blank", rel: "noreferrer" } : undefined
 
             return (
               <motion.article
-                className={index === 0 ? "dtz-proof-surface is-featured" : "dtz-proof-surface"}
+                className="dtz-proof-surface"
                 key={item.title}
                 {...reveal(index * 0.06)}
                 viewport={{ once: true, amount: 0.25 }}
               >
-                {item.external ? (
-                  <a className="dtz-proof-surface-media" href={item.href} {...linkProps}>
-                    {media}
-                  </a>
-                ) : (
-                  <Link className="dtz-proof-surface-media" href={item.href}>
-                    {media}
-                  </Link>
-                )}
                 <div className="dtz-proof-surface-copy">
                   <ul className="dtz-tag-list" aria-label={`${item.title} status`}>
                     {item.badges.map((badge) => (
@@ -242,57 +179,51 @@ export function HomePage({ labNotes }: { labNotes: WriteupMeta[] }) {
                     ))}
                   </ul>
                   <h3>{item.title}</h3>
-                  <dl className="dtz-system-lines">
-                    <div>
-                      <dt>Problem</dt>
-                      <dd>{item.problem}</dd>
-                    </div>
-                    <div>
-                      <dt>Built</dt>
-                      <dd>{item.built}</dd>
-                    </div>
-                    <div>
-                      <dt>Proves</dt>
-                      <dd>{item.proves}</dd>
-                    </div>
-                  </dl>
+                  <p>{item.result}</p>
+                  {item.context ? <p>{item.context}</p> : null}
                   <a href={item.href} {...linkProps}>
                     {item.linkLabel}
                     <ArrowUpRight aria-hidden="true" />
                   </a>
+                  {item.secondaryHref && item.secondaryLabel ? (
+                    <a href={item.secondaryHref} target="_blank" rel="noreferrer">
+                      {item.secondaryLabel}
+                      <ArrowUpRight aria-hidden="true" />
+                    </a>
+                  ) : null}
                 </div>
               </motion.article>
             )
           })}
         </div>
 
-        <ul className="dtz-lane-list" aria-label="Other working lanes">
-          {workLanes.map((lane) => (
-            <li key={lane.title}>
-              <span className="dtz-lane-label">{lane.label}</span>
-              <div>
-                <strong>{lane.title}</strong>
-                <p>{lane.line}</p>
-              </div>
-              {lane.href && lane.linkLabel ? (
-                <a className="dtz-card-link" href={lane.href}>
-                  {lane.linkLabel}
-                  <ArrowUpRight aria-hidden="true" />
-                </a>
-              ) : null}
-            </li>
-          ))}
-        </ul>
+        <div className="dtz-lab-strip">
+          <p className="dtz-section-label">Lab log</p>
+          <ol className="dtz-lab-list">
+            {labNotes.map((note) => (
+              <li key={note.slug}>
+                <span className="dtz-lab-date">{note.date}</span>
+                <div>
+                  <Link href={`/writeups/${note.slug}`}>{note.title}</Link>
+                  <ul className="dtz-tag-list" aria-label={`${note.title} tags`}>
+                    <li>{note.category}</li>
+                    <li>{note.difficulty}</li>
+                  </ul>
+                </div>
+              </li>
+            ))}
+          </ol>
+          <Link className="dtz-card-link" href="/writeups">
+            All writeups
+            <ArrowUpRight aria-hidden="true" />
+          </Link>
+        </div>
       </section>
 
       <section id="process" className="dtz-section" aria-labelledby="process-title">
         <div className="dtz-section-heading">
           <p className="dtz-section-label">How I work</p>
-          <h2 id="process-title">How I keep projects grounded.</h2>
-          <p>
-            The common thread is verification. I would rather inspect the actual surface and make a smaller honest
-            improvement than write a big plan that never reaches the browser.
-          </p>
+          <h2 id="process-title">Same loop for security work and software.</h2>
         </div>
 
         <div className="dtz-process-grid">
@@ -311,113 +242,14 @@ export function HomePage({ labNotes }: { labNotes: WriteupMeta[] }) {
         </div>
       </section>
 
-      <section id="lab" className="dtz-section" aria-labelledby="lab-title">
-        <div className="dtz-section-heading">
-          <p className="dtz-section-label">From the lab</p>
-          <h2 id="lab-title">Latest writeups, dated and inspectable.</h2>
-          <p>
-            Technique-first writeups from real challenges: what broke, how it was approached, and what it proves. Flags
-            and live details stay redacted.
-          </p>
-        </div>
-
-        <ol className="dtz-lab-list">
-          {labNotes.map((note) => (
-            <li key={note.slug}>
-              <span className="dtz-lab-date">{note.date}</span>
-              <div>
-                <Link href={`/writeups/${note.slug}`}>{note.title}</Link>
-                <ul className="dtz-tag-list" aria-label={`${note.title} tags`}>
-                  <li>{note.category}</li>
-                  <li>{note.difficulty}</li>
-                </ul>
-              </div>
-            </li>
-          ))}
-        </ol>
-
-        <Link className="dtz-card-link" href="/writeups">
-          Open the lab log
-          <ArrowUpRight aria-hidden="true" />
-        </Link>
-      </section>
-
-      <section id="stack" className="dtz-section dtz-stack-section" aria-labelledby="stack-title">
-        <div className="dtz-section-heading">
-          <p className="dtz-section-label">Stack</p>
-          <h2 id="stack-title">Tools behind the calm handoff.</h2>
-          <p>
-            Visitors should not have to care about the stack. I use it to make the finished setup fast, reliable,
-            secure enough for the job, and easier to maintain.
-          </p>
-        </div>
-
-        <div className="dtz-stack-grid">
-          {stackGroups.map((group) => (
-            <article className="dtz-stack-group" key={group.title}>
-              <h3>{group.title}</h3>
-              <ul>
-                {group.items.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section id="notes" className="dtz-section dtz-notes-section" aria-labelledby="notes-title">
-        <div className="dtz-notes-layout">
-          <div>
-            <p className="dtz-section-label">Operating notes</p>
-            <h2 id="notes-title">What I&apos;m paying attention to right now.</h2>
-            <p>
-              This is the living part of the portfolio: systems thinking, practical security habits, useful automation,
-              and proof that survives beyond a sales conversation.
-            </p>
-          </div>
-
-          <div className="dtz-notes-panel">
-            <Image src="/visuals/generated-lanes.webp" alt="" width={1774} height={887} />
-            <ul className="dtz-check-list">
-              {currentFocus.map((line) => (
-                <li key={line}>
-                  <CheckCircle2 aria-hidden="true" />
-                  <span>{line}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </section>
-
       <section id="contact" className="dtz-contact dtz-overhaul-contact" aria-labelledby="contact-title">
         <div>
           <p className="dtz-section-label">Contact</p>
-          <h2 id="contact-title">Start a conversation about the work.</h2>
-          <p>
-            You do not need a polished brief. Send the project, the problem, the current link or file if you have one,
-            and what would make the next step useful. I keep the public contact path screened so the phone number is not
-            treated like an open spam target.
-          </p>
+          <h2 id="contact-title">Send the target, the question, or the build.</h2>
+          <p>WhatsApp is fastest. Email works. The code is public.</p>
         </div>
 
         <div className="dtz-contact-panel">
-          <div className="dtz-contact-card">
-            <span>Best first message</span>
-            <p>What are you trying to build or fix, and what is the current state?</p>
-          </div>
-          <div className="dtz-contact-card dtz-contact-guard">
-            <span>Phone spam guard</span>
-            <ul>
-              {contactGuardrails.map((item) => (
-                <li key={item}>
-                  <ShieldCheck aria-hidden="true" />
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
           <div className="dtz-contact-actions">
             <ProtectedWhatsAppLink
               className="dtz-button primary"
@@ -426,15 +258,6 @@ export function HomePage({ labNotes }: { labNotes: WriteupMeta[] }) {
               rel="noreferrer"
             >
               Message me on WhatsApp
-              <MessageCircle aria-hidden="true" />
-            </ProtectedWhatsAppLink>
-            <ProtectedWhatsAppLink
-              className="dtz-button secondary"
-              href="/contact/whatsapp?intent=callback"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Request a call-back
               <MessageCircle aria-hidden="true" />
             </ProtectedWhatsAppLink>
             <a className="dtz-button secondary" href={`mailto:${contact.email}`}>

--- a/data/content.ts
+++ b/data/content.ts
@@ -1,120 +1,78 @@
-// Homepage "Selected systems" tier: 3 flagship builds, each in the spec format
-// problem -> what I built -> what it proves (docs/IDENTITY-AND-DESIGN-DIRECTION.md).
-// Keep claims honest and links live; badges are Status / Type per the spec.
-export type FlagshipSystem = {
+import { businessSiteUrl } from "@/lib/site-config"
+
+// Hero credential chips. Each one must stay checkable against a source that is
+// linked somewhere on the page (the proof cards below).
+export const heroChips = [
+  "NCL Fall 2025: 24th of 620, Experienced",
+  "Gray Swan: 42 unique breaks",
+  "3 production systems live",
+]
+
+// Homepage proof tier: one artifact, one result, one link per card.
+// Numbers come from the linked source or they do not ship.
+export type ProofCard = {
   badges: string[]
   title: string
-  problem: string
-  built: string
-  proves: string
-  image: string
-  alt: string
+  result: string
+  context?: string
   href: string
   linkLabel: string
   external?: boolean
+  secondaryHref?: string
+  secondaryLabel?: string
 }
 
-export const flagshipSystems: FlagshipSystem[] = [
+export const proofCards: ProofCard[] = [
   {
-    badges: ["Client", "Live"],
-    title: "Local-business web system",
-    problem:
-      "A real local service business needed a credible web surface with clear services and a direct quote path.",
-    built:
-      "A bilingual site with service pages, photos, and quote flows, plus the working layer around it: domain, official inbox, social and WhatsApp paths, and a security-minded handoff.",
-    proves: "I can ship a customer-facing system end to end and leave the owner able to run it.",
-    image: "/portfolio/hernandez/site-trust-screenshot.png",
-    alt: "Screenshot of the Hernandez Landscape website trust and services section.",
-    href: "/portfolio",
-    linkLabel: "Inspect the live build",
+    badges: ["AI security", "Arena"],
+    title: "Gray Swan Arena: frontier-model breaks",
+    result:
+      "42 unique breaks across authorized arenas, including 21 in the Indirect Prompt Injection Q2 2026 wave (76th of 232). Winner's Circle member.",
+    context:
+      "Authorized competition and independent research against frontier-model agents, not client pentests.",
+    href: "https://app.grayswan.ai/arena/user/67d3110be637c128d0cca612",
+    linkLabel: "Public arena profile",
+    external: true,
   },
   {
-    badges: ["Product", "Live demo"],
+    badges: ["CTF", "Ranked"],
+    title: "National Cyber League, Fall 2025",
+    result:
+      "24th of 620 overall in the Experienced bracket, 97th percentile. 1st of 620 in Log Analysis, 3rd in Network Traffic Analysis, 7th in Web Application Exploitation.",
+    href: "https://cyberskyline.com/report/BC2QQYBBP3L3",
+    linkLabel: "Official score report",
+    external: true,
+  },
+  {
+    badges: ["Product", "Live"],
     title: "PromptDefenders",
-    problem: "AI-assisted workflows trust untrusted input by default, and prompt injection exploits exactly that.",
-    built:
-      "A prompt-injection defense project: evaluation methodology, safe test cases, and checklists for hardening AI-assisted workflows.",
-    proves: "Security thinking applied to AI systems as working artifacts, not just claims.",
-    image: "/visuals/proof-asset-gallery.svg",
-    alt: "Illustration of a gallery of proof assets for prompt-defense work.",
+    result:
+      "A prompt-injection scanner that scores text against a versioned rule pack: instruction override, data exfiltration, and tool misuse, flagged before a model sees them.",
     href: "https://prompt-defenders.vercel.app",
-    linkLabel: "Open the live demo",
+    linkLabel: "Run the live scanner",
     external: true,
+    secondaryHref: "https://github.com/RazonIn4K/prompt-defenders",
+    secondaryLabel: "Source",
   },
   {
-    badges: ["Lab", "Live"],
-    title: "Razon Live Lab",
-    problem: "Learning in private leaves no evidence, and unverifiable skill claims are worth little.",
-    built:
-      "A public lab for AI security and systems: streams, writeups, and sanitized demos, in English and Spanish.",
-    proves: "Consistent learning in public, with artifacts people can check.",
-    image: "/visuals/generated-lanes.webp",
-    alt: "Illustration of parallel working lanes in a live lab.",
-    href: "https://razonlab.com",
-    linkLabel: "Visit the lab",
+    badges: ["Client build", "Live"],
+    title: "Hernandez Landscape",
+    result:
+      "A bilingual services site for a real landscaping business: quote flow, gallery, and local SEO. Shipped, handed off, and running without me.",
+    href: "https://hernandezlandscapeservices.com",
+    linkLabel: "Visit the live site",
     external: true,
+    secondaryHref: `${businessSiteUrl}/contact`,
+    secondaryLabel: "Scope similar work",
   },
-]
-
-// The rest of the bench: working lanes that back the flagship systems.
-export type WorkLane = {
-  label: string
-  title: string
-  line: string
-  href?: string
-  linkLabel?: string
-}
-
-export const workLanes: WorkLane[] = [
-  {
-    label: "Delivery",
-    title: "Multi-AI delivery workflow",
-    line: "Research, implementation, review, QA, and documentation split into visible steps instead of one prompt.",
-  },
-  {
-    label: "Knowledge",
-    title: "RAG and notes tools",
-    line: "Retrieval, cited answers, and the habit of checking the source before trusting a generated answer.",
-  },
-  {
-    label: "Ops",
-    title: "Automation and cleanup",
-    line: "Small automations for intake, follow-up, and deployment checks, documented before they count as done.",
-  },
-  {
-    label: "Demos",
-    title: "Spanish-first local-business demos",
-    line: "Pedidos, citas, servicios: flows for owners and customers who live on mobile, WhatsApp, and social.",
-    href: "/demo",
-    linkLabel: "Open the demos",
-  },
-]
-
-// Hero NOW/LAST SHIPPED strip and the Notes section's current-focus list live
-// together so there is one honest update point: refresh `now` + `currentFocus`
-// when the working focus shifts, and `lastShipped` whenever something real ships.
-export const heroStatus = {
-  now: "prompt-defense evals · multi-AI delivery workflows · learning in public",
-  lastShipped: {
-    label: "CTF writeups + proof cards",
-    href: "/writeups",
-    date: "Jun 2026",
-  },
-}
-
-export const currentFocus = [
-  "Cleaner local-business websites with quote, order, or contact flows that do not feel overbuilt.",
-  "Repeatable AI-assisted delivery: research, implementation, review, browser QA, and a written handoff.",
-  "AI-security workflow habits, especially prompt injection, tool boundaries, and validation.",
-  "Better notes that preserve what worked, what failed, and what should happen in the next session.",
 ]
 
 export const chatConfig = {
-  title: 'PORTFOLIO GUIDE',
-  subtitle: 'Ask about the work, current experiments, or how he approaches projects',
-  placeholder: 'Ask about projects, automation workflows, or how David works.',
+  title: 'SITE GUIDE',
+  subtitle: 'Ask about the security work, the builds, or how to reach David',
+  placeholder: 'Ask about the arena results, PromptDefenders, or the builds.',
   welcomeMessage:
-    "Hi! This is David's personal portfolio. Ask about what he's building, how he works, or what he's exploring next.",
+    "Hi! This is David's personal site. Ask about the AI-security work, the builds, or how to get in touch.",
 }
 
 // Centralized contact details. A public business number/email is not a secret;


### PR DESCRIPTION
## Summary

Repositions davidtiz.com around one identity: an AI-security / offensive-evaluation engineer who also ships production software. Stacked on #83 (top of the #81 <- #82 <- #83 design chain).

- **Homepage** rebuilt to hero (identity sentence + 3 credential chips), 4 proof cards, compact lab log, 3-step process, one-line contact with WhatsApp/email/GitHub. Cut: status strip, work lanes, stack section, notes section, spam-guard essay, self-narrating and self-diminishing copy.
- **/portfolio** rewritten as a proof index (Gray Swan, NCL, PromptDefenders, CTF writeups, RayBridge, Hernandez). Hernandez is one entry; scoping links out to highencodelearning.com.
- **Gray Swan card** links the public arena profile (Razon: 42 unique breaks, 21 in IPI Q2 2026 at 76/232, Winner's Circle) so every number is checkable at its linked source.
- **Metadata/JSON-LD**, chat system prompt, and canned fallbacks aligned; ~380 lines of dead section CSS removed; CLAUDE.md synced.
- Stack, theme toggle, reduced-motion behavior, screened WhatsApp redirect, and all route-handler logic untouched.

## Verification

- `npm run lint` clean, `npm test` 51/51, `npm run build` passes
- Browser-checked `/` and `/portfolio` in light + dark against the production build
- Brand-boundary copy audit (docs/BRAND-BOUNDARY.md grep): 0 hits
- No em-dashes in rendered HTML; homepage body copy ~260 words
- Secret scan of the diff: clean

## Claims flagged for David to confirm

1. "Subscribe-On-Summarize, 4 breaks in the Q2 2026 wave" was dropped: the public profile shows 4 breaks in IPI **June '26** and 21 in IPI **Q2 2026**; behavior-level detail is not visible at the link. Shipped copy uses only profile-verifiable numbers.
2. The "30/30 break in an earlier wave" is not visible on the public profile, so it was left out.
3. Hero chip "3 production systems live" counts PromptDefenders, Hernandez, and davidtiz.com itself.
4. "Raycast MCP starter kit" shipped as `raybridge` (the only matching public repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)